### PR TITLE
Move the constraint defining curtailment for to the `constraints_capacity` method.

### DIFF
--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -1,4 +1,28 @@
 #! format: off
+
+"""
+    constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+Function for creating the constraint on the maximum capacity of a `NonDisRES`.
+Also sets the constraint defining curtailment.
+"""
+function EMB.constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
+    @constraint(m, [t ∈ 𝒯],
+        m[:cap_use][n, t] <= m[:cap_inst][n, t]
+    )
+
+    # Non dispatchable renewable energy sources operate at their max
+    # capacity with repsect to the current profile (e.g. wind) at every time.
+    @constraint(
+        m,
+        [t ∈ 𝒯],
+        m[:cap_use][n, t] + m[:curtailment][n, t] == profile(n, t) * m[:cap_inst][n, t]
+    )
+
+    constraints_capacity_installed(m, n, 𝒯, modeltype)
+end
+
+
 """
     EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -8,39 +8,8 @@ function EMB.variables_node(m, 𝒩ⁿᵈʳ::Vector{NonDisRES}, 𝒯, modeltype:
     @variable(m, curtailment[𝒩ⁿᵈʳ, 𝒯] >= 0)
 end
 
-"""
-    EMB.create_node(m, n::NonDisRES, 𝒯, 𝒫, modeltype::EnergyModel)
-
-Sets all constraints for a non-dispatchable renewable energy source.
-"""
-function EMB.create_node(m, n::NonDisRES, 𝒯, 𝒫, modeltype::EnergyModel)
-
-    # Declaration of the required subsets.
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-
-    # Non dispatchable renewable energy sources operate at their max
-    # capacity with repsect to the current profile (e.g. wind) at every time.
-    @constraint(
-        m,
-        [t ∈ 𝒯],
-        m[:cap_use][n, t] + m[:curtailment][n, t] == profile(n, t) * m[:cap_inst][n, t]
-    )
-
-    # Call of the function for the outlet flow from the `Source` node
-    constraints_flow_out(m, n, 𝒯, modeltype)
-
-    # Call of the function for limiting the capacity to the maximum installed capacity
-    constraints_capacity(m, n, 𝒯, modeltype)
-
-    # Call of the functions for both fixed and variable OPEX constraints introduction
-    constraints_opex_fixed(m, n, 𝒯ᴵⁿᵛ, modeltype)
-    constraints_opex_var(m, n, 𝒯ᴵⁿᵛ, modeltype)
-
-    # Iterate through all data and set up the constraints corresponding to the data
-    for data ∈ node_data(n)
-        constraints_data(m, n, 𝒯, 𝒫, modeltype, data)
-    end
-end
+# NB: note that the create_node method that will run for a node n::NonDisRES, is the
+# method defined for a general Source node, which is located in EnergyModelsBase.
 
 """
     EMB.variables_node(m, 𝒩::Vector{HydroStorage}, 𝒯, modeltype::EnergyModel)


### PR DESCRIPTION
This will make it easier to rewrite this constraint for other packages, and also allows simplifying the code by removing the `create_node` method for `NonDisRES` entirely, since it is now identical to the `create_node` method defined for a general `Source` node in `EnergyModelsBase`.