### PR TITLE
Adaptation to changes introduced in EMB v0.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.6.0 (2024-05-28)
+
+* Adjusted to changes introduced in `EnergyModelsBase` v0.7.
+* Remove legacy constructor for `RegHydroStor` and provide a warning for it.
+* Added constructors for `HydroStor` not requiring any longer specifying an input dictionary.
+
 ## Version 0.5.6 (2024-05-09)
 
 * Provided a contribution section in the documentation.

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "^0.6.7"
+EnergyModelsBase = "^0.7.0"
 JuMP = "1.5"
-TimeStruct = "^0.7.0"
+TimeStruct = "^0.8.0"
 julia = "^1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRenewableProducers"
 uuid = "b007c34f-ba52-4995-ba37-fffe79fbde35"
 authors = ["Sigmund Eggen Holm <Sigmund.Holm@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.5.6"
+version = "0.6.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,18 +27,20 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Manual" => Any[
-            "Quick Start"=>"manual/quick-start.md",
-            "Optimization variables"=>"manual/optimization-variables.md",
-            "Constraint functions"=>"manual/constraint-functions.md",
-            "Examples"=>"manual/simple-example.md",
+            "Quick Start" => "manual/quick-start.md",
+            "Optimization variables" => "manual/optimization-variables.md",
+            "Constraint functions" => "manual/constraint-functions.md",
+            "Examples" => "manual/simple-example.md",
             "Release notes" => "manual/NEWS.md",
         ],
         "How to" => Any[
             "Update models" => "how-to/update-models.md",
             "Contribute to EnergyModelsRenewableProducers" => "how-to/contribute.md",
         ],
-        "Library" =>
-            Any["Public"=>"library/public.md", "Internals"=>"library/internals.md"],
+        "Library" => Any[
+            "Public" => "library/public.md",
+            "Internals" => "library/internals.md",
+        ],
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,6 +34,7 @@ makedocs(
             "Release notes" => "manual/NEWS.md",
         ],
         "How to" => Any[
+            "Update models" => "how-to/update-models.md",
             "Contribute to EnergyModelsRenewableProducers" => "how-to/contribute.md",
         ],
         "Library" =>

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -1,0 +1,154 @@
+# Update your model to the latest versions
+
+`EnergyModelsRenewableProducers` is still in a pre-release version.
+Hence, there are frequently breaking changes occuring, although we plan to keep backwards compatibility.
+This document is designed to provide users with information regarding how they have to adjust their models to keep compatibility to the latest changes.
+We will as well implement information regarding the adjustment of extension packages, although this is more difficult due to the vast majority of potential changes.
+
+## Adjustments from 0.4.2
+
+### Key changes for nodal descriptions
+
+Version 0.7 of `EnergyModelsBase` introduced both *storage behaviours* resulting in a rework of the individual approach for calculating the level balance as well as the potential to have charge and discharge capacities through *storage parameters*.
+
+!!! note
+    The legacy constructors for calls of the composite type of version 0.5 will be included at least until version 0.7.
+
+### [`HydroStor`](@ref)
+
+`HydroStor` was significantly reworked due to the changes in `EnergyModelsBase`
+The total rework is provided below.
+
+If you are previously using the functions [`capacity`](@ref), [`opex_var`](@ref), and [`opex_fixed`](@ref) directly on the nodal type, you have to adjust as well your call of the function as they now require the call on the `StorageParameter` type.
+
+```julia
+# The previous nodal description for a `HydroStor` node was given by:
+HydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+    data::Vector{Data},
+)
+
+# This translates to the following new version
+HydroStor{CyclicStrategic}(
+    id,
+    StorCapOpexFixed(stor_cap, opex_fixed),
+    StorCapOpexVar(rate_cap, opex_var),
+    level_init,
+    level_inflow,
+    level_min,
+    stor_res,
+    input,
+    output,
+    data,
+)
+```
+
+### [`PumpedHydroStor`](@ref)
+
+`HydroStor` was significantly reworked due to the changers in `EnergyModelsBase`
+The total rework is provided below.
+
+If you are previously using the functions [`capacity`](@ref), [`opex_var`](@ref), and [`opex_fixed`](@ref) directly on the nodal type, you have to adjust as well your call of the function as they now require the call on the `StorageParameter` type.
+
+```julia
+# The previous nodal description for a `PumpedHydroStor` node was given by:
+PumpedHydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_var_pump::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+    data::Vector{Data},
+)
+
+# This translates to the following new version
+PumpedHydroStor{CyclicStrategic}(
+    id,
+    StorCapOpexVar(rate_cap, opex_var_pump),
+    StorCapOpexFixed(stor_cap, opex_fixed),
+    StorCapOpexVar(rate_cap, opex_var),
+    level_init,
+    level_inflow,
+    level_min,
+    stor_res,
+    input,
+    output,
+    data,
+)
+```
+
+## Adjustments from 0.4.0 to 0.6.x
+
+### Key changes for nodal descriptions
+
+Version 0.4.1 introduced two new types that replaced the original `RegHydroStor` node with two types called [`PumpedHydroStor`](@ref) and [`HydroStor](@ref).
+The changes allowed for the introduction of a variable OPEX for pumping.
+In the translation below, it is assumed that the variable OPEX for pumping is 0.
+
+```julia
+# The previous nodal description was given by:
+RegHydroStor(
+    id::Any,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+    has_pump::Bool,
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input,
+    output,
+    Data,
+)
+
+# This translates to the following new version if has_pump == true
+PumpedHydroStor(
+    id,
+    StorCapOpexVar(rate_cap, FixedProfile(0)),
+    StorCapOpexFixed(stor_cap, opex_fixed),
+    StorCapOpexVar(rate_cap, opex_var),
+    level_init,
+    level_inflow,
+    level_min,
+    stor_res,
+    input,
+    output,
+    Data,
+)
+# and the following version if has_pump == false
+HydroStor(
+    id,
+    StorCapOpexFixed(stor_cap, opex_fixed),
+    StorCapOpexVar(rate_cap, opex_var),
+    level_init,
+    level_inflow,
+    level_min,
+    stor_res,
+    input,
+    output,
+    Data,
+)
+```

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -1,4 +1,4 @@
-# Update your model to the latest versions
+# [Update your model to the latest versions](@id update-models)
 
 `EnergyModelsRenewableProducers` is still in a pre-release version.
 Hence, there are frequently breaking changes occuring, although we plan to keep backwards compatibility.
@@ -18,8 +18,6 @@ Version 0.7 of `EnergyModelsBase` introduced both *storage behaviours* resulting
 
 `HydroStor` was significantly reworked due to the changes in `EnergyModelsBase`
 The total rework is provided below.
-
-If you are previously using the functions [`capacity`](@ref), [`opex_var`](@ref), and [`opex_fixed`](@ref) directly on the nodal type, you have to adjust as well your call of the function as they now require the call on the `StorageParameter` type.
 
 ```julia
 # The previous nodal description for a `HydroStor` node was given by:
@@ -57,10 +55,8 @@ HydroStor{CyclicStrategic}(
 
 ### [`PumpedHydroStor`](@ref)
 
-`HydroStor` was significantly reworked due to the changers in `EnergyModelsBase`
+`PumpedHydroStor` was significantly reworked due to the changers in `EnergyModelsBase`
 The total rework is provided below.
-
-If you are previously using the functions [`capacity`](@ref), [`opex_var`](@ref), and [`opex_fixed`](@ref) directly on the nodal type, you have to adjust as well your call of the function as they now require the call on the `StorageParameter` type.
 
 ```julia
 # The previous nodal description for a `PumpedHydroStor` node was given by:
@@ -102,7 +98,7 @@ PumpedHydroStor{CyclicStrategic}(
 
 ### Key changes for nodal descriptions
 
-Version 0.4.1 introduced two new types that replaced the original `RegHydroStor` node with two types called [`PumpedHydroStor`](@ref) and [`HydroStor](@ref).
+Version 0.4.1 introduced two new types that replaced the original `RegHydroStor` node with two types called [`PumpedHydroStor`](@ref) and [`HydroStor`](@ref).
 The changes allowed for the introduction of a variable OPEX for pumping.
 In the translation below, it is assumed that the variable OPEX for pumping is 0.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,6 +25,7 @@ Pages = [
     "manual/constraint-functions.md",
     "manual/simple-example.md"
 ]
+Depth = 1
 ```
 
 ## How to guides
@@ -32,7 +33,9 @@ Pages = [
 ```@contents
 Pages = [
     "how-to/contribute.md",
+    "how-to/update-models.md",
 ]
+Depth = 1
 ```
 
 ## Library outline
@@ -41,5 +44,6 @@ Pages = [
 Pages = [
     "library/public.md"
     "library/internals.md"
-    ]
+]
+Depth = 1
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -27,9 +27,10 @@ A hydropower plant is much more flexible than, *e.g.*, a wind farm since the wat
 Energy can be produced (almost) whenever it is needed.
 Some hydropower plants also have pumps installed.
 These are used to pump water into the reservoir when excess and cheap energy is available in the network.
+`EnergyModelsRenewableProducers` introduces hence two different types representing a regulated hydropower plant ([`HydroStor`](@ref)) and a pumped regulated hydropower plant ([`PumpedHydroStor`](@ref)) without a lower reservoir.
+Both types have a `level` and `discharge` capacity while a `PumpedHydroStor` also includes a `charge` capacity.
 
-The field `rate_cap` describes the installed production capacity of the (aggregated) hydropower plant.
-The variable `level_init` represents the initial energy available in the reservoir in the beginning of each investment period, while `stor_cap` is the installed storage capacity in the reservoir.
+The variable `level_init` represents the initial energy available in the reservoir in the beginning of each investment period.
 The variable `level_inflow` describes the inflow into the reservoir (measured in energy units), while `level_min` is the allowed minimum storage level in the dam, given as a ratio of the installed storage capacity of the reservoir at
 every operational period.
 The required minimum level is enforced by NVE and varies over the year.
@@ -38,16 +39,6 @@ The resources stored in the hydro storage is set as `stor_res`, similar to a reg
 The five last parameters are used in the same way as in `EMB.Storage`.
 In the implementation of [`PumpedHydroStor`](@ref), the values set in `input` represents a loss of energy when using the pumps.
 A value of `1` means no energy loss, while a value of `0` represents 100% energy loss of that inflow variable.
-[`PumpedHydroStor`](@ref) has in addition the field `opex_var_pump::TimeProfile`.
-This field corresponds to the variable operational expenditures when pumping water into the storage reservoir.
-
-Since we also want to be able to model hydropower plant nodes *without* pumps, we include the boolean `has_pump` in the type describing hydropower.
-For combining the behavior of a hydropower plant with and without a pump, we can disable the inflow of energy by setting the constraint
-
-  ``\texttt{flow\_in}[n, t, p_{\texttt{Power}}] = 0,``
-
-for the stored resource ``p_{\texttt{Power}}`` for the node ``n`` `::HydroStor`.
-To access this variable, we therefore have to let the type `HydroStorage` be a subtype of `EMB.Storage`.
 
 The fields of the different types are listed below:
 
@@ -55,5 +46,4 @@ The fields of the different types are listed below:
 HydroStorage
 HydroStor
 PumpedHydroStor
-RegHydroStor
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -47,3 +47,16 @@ HydroStorage
 HydroStor
 PumpedHydroStor
 ```
+
+In recent version increases, we changed the individual fields of the `HydroStorage` nodes as well as their types.
+Hence, we still incorporate legacy constructors that can be utilized when having a model in previous versions.
+However, we removed one legacy constructor as it is no longer required.
+Calling the constructor will provide you now with an error.
+
+This legacy constructor is:
+
+```@docs
+RegHydroStor
+```
+
+See the section on *[how to update models](@ref update-models)* for further information regarding how you can translate your existing model to the new model.

--- a/docs/src/manual/NEWS.md
+++ b/docs/src/manual/NEWS.md
@@ -1,9 +1,15 @@
 # Release notes
 
-## Unversioned
+## Version 0.6.0 (2024-05-28)
 
-* Updated a link in the documentation for the examples.
+* Adjusted to changes introduced in `EnergyModelsBase` v0.7.
+* Remove legacy constructor for `RegHydroStor` and provide a warning for it.
+* Added constructors for `HydroStor` not requiring any longer specifying an input dictionary.
+
+## Version 0.5.6 (2024-05-09)
+
 * Provided a contribution section in the documentation.
+* Fixed a link in the documentation for the examples.
 
 ## Version 0.5.5 (2024-03-21)
 

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -35,7 +35,7 @@ The spillage is introduced to allow for an overflow from a reservoir if the infl
 
 The variable is used in the following constraint [`EMB.constraints_level_aux`](@ref),
 
-  ``\texttt{stor\_level\_}\Delta\texttt{\_op}[n, t] = \texttt{level\_inflow}(n, t) + \texttt{inputs}(n, p_{\texttt{Power}}) \cdot \texttt{flow\_in}[n, t] + \texttt{stor\_rate\_use}[n, t] - \texttt{hydro\_spill}[n, t]``
+  ``\texttt{stor\_level\_}\Delta\texttt{\_op}[n, t] = \texttt{level\_inflow}(n, t) + \texttt{inputs}(n, p_{\texttt{Power}}) \cdot \texttt{flow\_in}[n, t] + \texttt{stor\_discharge\_use}[n, t] - \texttt{hydro\_spill}[n, t]``
 
 for the stored resource ``p_{\texttt{Power}}``.
 

--- a/examples/simple_hydro_power.jl
+++ b/examples/simple_hydro_power.jl
@@ -62,15 +62,19 @@ function generate_example_data()
     )
 
     # Create a regulated hydro power plant without storage capacity
-    hydro = HydroStor(
+    hydro = HydroStor{CyclicStrategic}(
         "hydropower",       # Node ID
-        FixedProfile(2.0),  # Rate capacity in MW
-        FixedProfile(90),   # Storage capacity in MWh
+        StorCapOpexFixed(FixedProfile(90), FixedProfile(3)),
+        # Line above for the storage level:
+        #   Argument 1: Storage capacity in MWh
+        #   Argument 2: Fixed OPEX in EUR/8h
+        StorCapOpexVar(FixedProfile(2.0), FixedProfile(8)),
+        # Line above for the discharge rate:
+        #   Argument 1: Rate capacity in MW
+        #   Argument 2: Variable OPEX in EUR/MWh
         FixedProfile(10),   # Initial storage level in MWh
         FixedProfile(1),    # Inflow to the Node in MW
         FixedProfile(0.0),  # Minimum storage level as fraction
-        FixedProfile(8),    # Variable OPEX in EUR/MWh
-        FixedProfile(3),    # Fixed OPEX in EUR/8h
         Power,              # Stored resource
         Dict(Power => 0.9), # Input to the power plant, irrelevant in this case
         Dict(Power => 1),   # Output from the Node, in this gase, Power

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -42,11 +42,15 @@ end
 This method checks that the *[`HydroStorage`](@ref HydroStorage_public)* node is valid.
 
 ## Checks
- - The value of the field `rate_cap` is required to be non-negative.
- - The value of the field `stor_cap` is required to be non-negative.
- - The value of the field `fixed_opex` is required to be non-negative and
-   accessible through a `StrategicPeriod` as outlined in the function
-   `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)`.
+- The `TimeProfile` of the field `capacity` in the type in the field `charge` is required
+  to be non-negative if the chosen composite type has the field `capacity`.
+- The `TimeProfile` of the field `capacity` in the type in the field `level` is required
+  to be non-negative`.
+- The `TimeProfile` of the field `capacity` in the type in the field `discharge` is required
+  to be non-negative if the chosen composite type has the field `capacity`.
+- The `TimeProfile` of the field `fixed_opex` is required to be non-negative and
+  accessible through a `StrategicPeriod` as outlined in the function
+  `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)` for the chosen composite type .
  - The field `output` can only include a single `Resource`.
  - The value of the field `output` is required to be smaller or equal to 1.
  - The value of the field `input` is required to be in the range ``[0, 1]``.
@@ -58,17 +62,36 @@ This method checks that the *[`HydroStorage`](@ref HydroStorage_public)* node is
 function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EMB.EnergyModel, check_timeprofiles::Bool)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    # cap = capacity(n)
+    par_charge = charge(n)
+    par_level = level(n)
+    par_discharge = discharge(n)
 
-    # @assert_or_log(
-    #     sum(cap.rate[t] < 0 for t ∈ 𝒯) == 0,
-    #     "The production capacity in field `rate_cap` has to be non-negative."
-    # )
-    # @assert_or_log(
-    #     sum(cap.level[t] < 0 for t ∈ 𝒯) == 0,
-    #     "The storage capacity in field `stor_cap` has to be non-negative."
-    # )
-    # EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    if isa(par_charge, EMB.UnionCapacity)
+        @assert_or_log(
+            sum(capacity(par_charge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            "The charge capacity must be non-negative."
+        )
+    end
+    if isa(par_charge, EMB.UnionOpexFixed)
+        EMB.check_fixed_opex(par_charge, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    end
+    @assert_or_log(
+        sum(capacity(par_level, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        "The level capacity must be non-negative."
+    )
+    if isa(par_level, EMB.UnionOpexFixed)
+        EMB.check_fixed_opex(par_level, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    end
+    if isa(par_discharge, EMB.UnionCapacity)
+        @assert_or_log(
+            sum(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            "The charge capacity must be non-negative."
+        )
+    end
+    if isa(par_discharge, EMB.UnionOpexFixed)
+        EMB.check_fixed_opex(par_discharge, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    end
+
     @assert_or_log(
         length(outputs(n)) == 1,
         "Only one resource can be stored, so only this one can flow out."
@@ -96,18 +119,17 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EMB.EnergyModel, check
         )
     end
 
-    # @assert_or_log(
-    #     sum(level_init(n, t) ≤ cap.level[t] for t ∈ 𝒯) == length(𝒯),
-    #     "The initial level `level_init` has to be less or equal to the max storage capacity."
-    # )
-    # for t_inv ∈ 𝒯ᴵⁿᵛ
-
-    #     t = first(t_inv)
-    #     # Check that the reservoir isn't underfilled from the start.
-    #     @assert_or_log(
-    #         level_init(n, t_inv) + level_inflow(n, t) ≥ level_min(n, t) * cap.level[t],
-    #         "The reservoir can't be underfilled from the start (" * string(t) * ").")
-    # end
+    @assert_or_log(
+        sum(level_init(n, t) ≤ capacity(par_level, t) for t ∈ 𝒯) == length(𝒯),
+        "The initial level `level_init` has to be less or equal to the max storage capacity."
+    )
+    for t_inv ∈ 𝒯ᴵⁿᵛ
+        t = first(t_inv)
+        # Check that the reservoir isn't underfilled from the start.
+        @assert_or_log(
+            level_init(n, t_inv) + level_inflow(n, t) ≥ level_min(n, t) * capacity(par_level, t),
+            "The reservoir can't be underfilled from the start (" * string(t) * ").")
+    end
 
     @assert_or_log(
         sum(level_init(n, t) < 0 for t ∈ 𝒯) == 0,

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -58,17 +58,17 @@ This method checks that the *[`HydroStorage`](@ref HydroStorage_public)* node is
 function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EMB.EnergyModel, check_timeprofiles::Bool)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    cap = capacity(n)
+    # cap = capacity(n)
 
-    @assert_or_log(
-        sum(cap.rate[t] < 0 for t ∈ 𝒯) == 0,
-        "The production capacity in field `rate_cap` has to be non-negative."
-    )
-    @assert_or_log(
-        sum(cap.level[t] < 0 for t ∈ 𝒯) == 0,
-        "The storage capacity in field `stor_cap` has to be non-negative."
-    )
-    EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    # @assert_or_log(
+    #     sum(cap.rate[t] < 0 for t ∈ 𝒯) == 0,
+    #     "The production capacity in field `rate_cap` has to be non-negative."
+    # )
+    # @assert_or_log(
+    #     sum(cap.level[t] < 0 for t ∈ 𝒯) == 0,
+    #     "The storage capacity in field `stor_cap` has to be non-negative."
+    # )
+    # EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
     @assert_or_log(
         length(outputs(n)) == 1,
         "Only one resource can be stored, so only this one can flow out."
@@ -96,18 +96,18 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EMB.EnergyModel, check
         )
     end
 
-    @assert_or_log(
-        sum(level_init(n, t) ≤ cap.level[t] for t ∈ 𝒯) == length(𝒯),
-        "The initial level `level_init` has to be less or equal to the max storage capacity."
-    )
-    for t_inv ∈ 𝒯ᴵⁿᵛ
+    # @assert_or_log(
+    #     sum(level_init(n, t) ≤ cap.level[t] for t ∈ 𝒯) == length(𝒯),
+    #     "The initial level `level_init` has to be less or equal to the max storage capacity."
+    # )
+    # for t_inv ∈ 𝒯ᴵⁿᵛ
 
-        t = first(t_inv)
-        # Check that the reservoir isn't underfilled from the start.
-        @assert_or_log(
-            level_init(n, t_inv) + level_inflow(n, t) ≥ level_min(n, t) * cap.level[t],
-            "The reservoir can't be underfilled from the start (" * string(t) * ").")
-    end
+    #     t = first(t_inv)
+    #     # Check that the reservoir isn't underfilled from the start.
+    #     @assert_or_log(
+    #         level_init(n, t_inv) + level_inflow(n, t) ≥ level_min(n, t) * cap.level[t],
+    #         "The reservoir can't be underfilled from the start (" * string(t) * ").")
+    # end
 
     @assert_or_log(
         sum(level_init(n, t) < 0 for t ∈ 𝒯) == 0,

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -33,7 +33,7 @@ function EMB.constraints_flow_in(m, n::HydroStor, 𝒯::TimeStructure, modeltype
 
     # Fix the inlet flow to a value of 0
     for t ∈ 𝒯, p ∈ 𝒫ⁱⁿ
-        fix(m[:flow_in][n, t, p], 0)
+        fix(m[:flow_in][n, t, p], 0; force=true)
     end
 end
 

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -22,6 +22,36 @@ function EMB.constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltyp
     constraints_capacity_installed(m, n, 𝒯, modeltype)
 end
 
+"""
+    constraints_flow_in(m, n::HydroStor, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+When `n::HydroStor`, the the variable `:flow_in` is fixed to 0 for all potential inputs.
+"""
+function EMB.constraints_flow_in(m, n::HydroStor, 𝒯::TimeStructure, modeltype::EnergyModel)
+    # Declaration of the required subsets
+    𝒫ⁱⁿ  = inputs(n)
+
+    # Fix the inlet flow to a value of 0
+    for t ∈ 𝒯, p ∈ 𝒫ⁱⁿ
+        fix(m[:flow_in][n, t, p], 0)
+    end
+end
+
+"""
+    constraints_flow_in(m, n, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+When `n::PumpedHydroStor`, the the variable `:flow_in` is used contrary to standard nodes,
+that is the variable `:flow_in` is multiplied with the `inputs` value.
+"""
+function EMB.constraints_flow_in(m, n::PumpedHydroStor, 𝒯::TimeStructure, modeltype::EnergyModel)
+    # Declaration of the required subsets
+    𝒫ⁱⁿ  = inputs(n)
+
+    # Constraint for the individual input stream connections
+    @constraint(m, [t ∈ 𝒯, p ∈ 𝒫ⁱⁿ],
+        m[:flow_in][n, t, p] * inputs(n, p) == m[:stor_charge_use][n, t]
+    )
+end
 
 """
     EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
@@ -33,7 +63,7 @@ The change in storage level in the reservoir at operational periods `t` is the i
 `level_inflow` plus the input `flow_in` minus the production `stor_rate_use` and the
 spillage of water due to overflow `hydro_spill`.
 """
-function EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
+function EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype::EnergyModel)
     # Declaration of the required subsets
     p_stor = storage_resource(n)
 
@@ -41,7 +71,7 @@ function EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
     @constraint(m, [t ∈ 𝒯],
         m[:stor_level_Δ_op][n, t] ==
             level_inflow(n, t) + inputs(n, p_stor) * m[:flow_in][n, t, p_stor] -
-            m[:stor_rate_use][n, t] - m[:hydro_spill][n, t]
+            m[:stor_discharge_use][n, t] - m[:hydro_spill][n, t]
     )
 
     # The initial storage level is given by the specified initial level in the strategic
@@ -54,176 +84,4 @@ function EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
     )
 end
 
-"""
-    EMB.constraints_level_sp(
-        m,
-        n::HydroStorage,
-        t_inv::TS.StrategicPeriod{T, U},
-        𝒫,
-        modeltype
-        ) where {T, U<:SimpleTimes}
-
-Function for creating the level constraint for a `HydroStorage` node when the
-TimeStructure is given as `SimpleTimes`.
-"""
-function EMB.constraints_level_sp(
-    m,
-    n::HydroStorage,
-    t_inv::TS.StrategicPeriod{T, U},
-    𝒫,
-    modeltype
-    ) where {T, U<:SimpleTimes}
-
-    # Energy balance constraints for stored hydro power.
-    for (t_prev, t) ∈ withprev(t_inv)
-        if isnothing(t_prev)
-            @constraint(m,
-                m[:stor_level][n, t] ==
-                    m[:stor_level][n, last(t_inv)] +
-                    m[:stor_level_Δ_op][n, t] * duration(t)
-            )
-        else
-            @constraint(m,
-                m[:stor_level][n, t] ==
-                    m[:stor_level][n, t_prev] +
-                    m[:stor_level_Δ_op][n, t] * duration(t)
-            )
-        end
-    end
-end
-
-"""
-    EMB.constraints_level_sp(
-        m,
-        n::HydroStorage,
-        t_inv::TS.StrategicPeriod{T, RepresentativePeriods{U, T, SimpleTimes{T}}},
-        𝒫,
-        modeltype
-        ) where {T, U}
-
-Function for creating the level constraint for a `HydroStorage` storage node when the
-operational `TimeStructure` is given as `RepresentativePeriods`.
-"""
-function EMB.constraints_level_sp(
-    m,
-    n::HydroStorage,
-    t_inv::TS.StrategicPeriod{T, RepresentativePeriods{U, T, SimpleTimes{T}}},
-    𝒫,
-    modeltype
-    ) where {T, U}
-
-    # Declaration of the required subsets
-    𝒯ʳᵖ = repr_periods(t_inv)
-
-    # Constraint for the total change in the level in a given representative period
-    @constraint(m, [t_rp ∈ 𝒯ʳᵖ],
-        m[:stor_level_Δ_rp][n, t_rp] ==
-            sum(m[:stor_level_Δ_op][n, t] * multiple_strat(t_inv, t) * duration(t) for t ∈ t_rp)
-    )
-
-    # Constraint that the total change has to be 0
-    @constraint(m, sum(m[:stor_level_Δ_rp][n, t_rp] for t_rp ∈ 𝒯ʳᵖ) == 0)
-
-    # Mass/energy balance constraints for stored energy carrier.
-    for (t_rp_prev, t_rp) ∈ withprev(𝒯ʳᵖ), (t_prev, t) ∈ withprev(t_rp)
-        if isnothing(t_rp_prev) && isnothing(t_prev)
-
-            # Last representative period in t_inv
-            t_rp_last = last(𝒯ʳᵖ)
-
-            # Constraint for the level of the first operational period in the first
-            # representative period in a strategic period
-            # The substraction of stor_level_Δ_op[n, first(t_rp_last)] is necessary to avoid
-            # treating the first operational period differently with respect to the level
-            # as the latter is at the end of the period
-            @constraint(m,
-                m[:stor_level][n, t] ==
-                    m[:stor_level][n, first(t_rp_last)] -
-                    m[:stor_level_Δ_op][n, first(t_rp_last)] * duration(first(t_rp_last)) +
-                    m[:stor_level_Δ_rp][n, t_rp_last] +
-                    m[:stor_level_Δ_op][n, t] * duration(t)
-            )
-
-            # Constraint to avoid starting below 0 in this operational period
-            @constraint(m,
-                m[:stor_level][n, t] -
-                m[:stor_level_Δ_op][n, t] * duration(t) ≥ 0
-            )
-
-            # Constraint to avoid having a level larger than the storage allows
-            @constraint(m,
-                m[:stor_level][n, t] -
-                m[:stor_level_Δ_op][n, t] * duration(t) ≤ m[:stor_cap_inst][n, t]
-            )
-
-        elseif isnothing(t_prev)
-            # Constraint for the level of the first operational period in any following
-            # representative period
-            # The substraction of stor_level_Δ_op[n, first(t_rp_prev)] is necessary to avoid
-            # treating the first operational period differently with respect to the level
-            # as the latter is at the end of the period
-            @constraint(m,
-                m[:stor_level][n, t] ==
-                    m[:stor_level][n, first(t_rp_prev)] -
-                    m[:stor_level_Δ_op][n, first(t_rp_prev)] * duration(first(t_rp_prev)) +
-                    m[:stor_level_Δ_rp][n, t_rp_prev] +
-                    m[:stor_level_Δ_op][n, t] * duration(t)
-            )
-
-            # Constraint to avoid starting below 0 in this operational period
-            @constraint(m,
-                m[:stor_level][n, t] - m[:stor_level_Δ_op][n, t] * duration(t) ≥
-                    level_min(n, t) * m[:stor_cap_inst][n, t]
-            )
-            # Constraint to avoid having a level larger than the storage allows
-            @constraint(m,
-                m[:stor_level][n, t] - m[:stor_level_Δ_op][n, t] * duration(t) ≤
-                    m[:stor_cap_inst][n, t]
-            )
-        else
-            # Constraint for the level of a standard operational period
-            @constraint(m,
-                m[:stor_level][n, t] ==
-                    m[:stor_level][n, t_prev] +
-                    m[:stor_level_Δ_op][n, t] * duration(t)
-            )
-        end
-    end
-end
-
 #! format: on
-"""
-    constraints_opex_var(m, n::HydroStor, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-
-Function for creating the constraint on the variable OPEX of a `HydroStor`.
-"""
-function EMB.constraints_opex_var(m, n::HydroStor, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-    p_stor = EMB.storage_resource(n)
-    @constraint(
-        m,
-        [t_inv ∈ 𝒯ᴵⁿᵛ],
-        m[:opex_var][n, t_inv] == sum(
-            m[:flow_out][n, t, p_stor] * opex_var(n, t) * EMB.multiple(t_inv, t) for
-            t ∈ t_inv
-        )
-    )
-end
-
-"""
-    constraints_opex_var(m, n::PumpedHydroStor, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-
-Function for creating the constraint on the variable OPEX of a `PumpedHydroStor`.
-"""
-function EMB.constraints_opex_var(m, n::PumpedHydroStor, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
-    p_stor = EMB.storage_resource(n)
-    @constraint(
-        m,
-        [t_inv ∈ 𝒯ᴵⁿᵛ],
-        m[:opex_var][n, t_inv] == sum(
-            (
-                m[:flow_in][n, t, p_stor] * opex_var_pump(n, t) +
-                m[:flow_out][n, t, p_stor] * opex_var(n, t)
-            ) * EMB.multiple(t_inv, t) for t ∈ t_inv
-        )
-    )
-end

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -57,7 +57,7 @@ end
     EMB.constraints_level_aux(m, n::HydroStorage, 𝒯, 𝒫, modeltype)
 
 Function for creating the Δ constraint for the level of a `HydroStorage` node as well as
-the specificaiton of the initial level in a strategic period.
+the specification of the initial level in a strategic period.
 
 The change in storage level in the reservoir at operational periods `t` is the inflow through
 `level_inflow` plus the input `flow_in` minus the production `stor_rate_use` and the

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -33,7 +33,7 @@ function NonDisRES(
 end
 
 """ An abstract type for hydro storage nodes, with or without pumping. """
-abstract type HydroStorage <: EMB.Storage end
+abstract type HydroStorage{T} <: EMB.Storage{T} end
 
 """ A regulated hydropower storage, modelled as a `Storage` node.
 
@@ -44,8 +44,6 @@ abstract type HydroStorage <: EMB.Storage end
 - **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.\n
 - **`level_inflow::TimeProfile`** Inflow of power per operational period.\n
 - **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.\n
-- **`opex_var::TimeProfile`** Operational cost per GWh produced.\n
-- **`opex_fixed::TimeProfile`** Fixed operational costs.\n
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.\n
 - **`input::Dict{Resource, Real}`** the stored and used resources. The \
 values in the Dict is a ratio describing the energy loss when using the pumps.\n
@@ -53,44 +51,38 @@ values in the Dict is a ratio describing the energy loss when using the pumps.\n
 - **`data::Vector{Data}`** additional data (e.g. for investments). The field \
 `data` is conditional through usage of a constructor.
 """
-struct HydroStor <: HydroStorage
+struct HydroStor{T} <: HydroStorage{T}
     id::Any
-    rate_cap::TimeProfile
-    stor_cap::TimeProfile
+    level::EMB.UnionCapacity
+    discharge::EMB.UnionCapacity
 
     level_init::TimeProfile
     level_inflow::TimeProfile
     level_min::TimeProfile
 
-    opex_var::TimeProfile
-    opex_fixed::TimeProfile
     stor_res::ResourceCarrier
     input::Dict{<:Resource, <:Real}
     output::Dict{<:Resource, <:Real}
     data::Vector{Data}
 end
-function HydroStor(
+function HydroStor{T}(
         id::Any,
-        rate_cap::TimeProfile,
-        stor_cap::TimeProfile,
+        level::EMB.UnionCapacity,
+        discharge::EMB.UnionCapacity,
         level_init::TimeProfile,
         level_inflow::TimeProfile,
         level_min::TimeProfile,
-        opex_var::TimeProfile,
-        opex_fixed::TimeProfile,
         stor_res::ResourceCarrier,
         input::Dict{<:Resource, <:Real},
         output::Dict{<:Resource, <:Real},
-    )
-    return HydroStor(
+    ) where {T<:EMB.StorageBehavior}
+    return HydroStor{T}(
         id,
-        rate_cap,
-        stor_cap,
+        level,
+        discharge,
         level_init,
         level_inflow,
         level_min,
-        opex_var,
-        opex_fixed,
         stor_res,
         input,
         output,
@@ -107,9 +99,6 @@ end
 - **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.\n
 - **`level_inflow::TimeProfile`** Inflow of power per operational period.\n
 - **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.\n
-- **`opex_var::TimeProfile`** Operational cost per GWh produced.\n
-- **`opex_var_pump::TimeProfile`** Operational cost per GWh pumped into the reservoir.\n
-- **`opex_fixed::TimeProfile`** Fixed operational costs.\n
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.\n
 - **`input::Dict{Resource, Real}`** the stored and used resources. The \
 values in the Dict is a ratio describing the energy loss when using the pumps.\n
@@ -117,47 +106,41 @@ values in the Dict is a ratio describing the energy loss when using the pumps.\n
 - **`data::Vector{Data}`** additional data (e.g. for investments). The field \
 `data` is conditional through usage of a constructor.\n
 """
-struct PumpedHydroStor <: HydroStorage
+struct PumpedHydroStor{T} <: HydroStorage{T}
     id::Any
-    rate_cap::TimeProfile
-    stor_cap::TimeProfile
+    charge::EMB.UnionCapacity
+    level::EMB.UnionCapacity
+    discharge::EMB.UnionCapacity
 
     level_init::TimeProfile
     level_inflow::TimeProfile
     level_min::TimeProfile
 
-    opex_var::TimeProfile
-    opex_var_pump::TimeProfile
-    opex_fixed::TimeProfile
     stor_res::ResourceCarrier
     input::Dict{<:Resource, <:Real}
     output::Dict{<:Resource, <:Real}
     data::Vector{Data}
 end
-function PumpedHydroStor(
+function PumpedHydroStor{T}(
         id::Any,
-        rate_cap::TimeProfile,
-        stor_cap::TimeProfile,
+        charge::EMB.UnionCapacity,
+        level::EMB.UnionCapacity,
+        discharge::EMB.UnionCapacity,
         level_init::TimeProfile,
         level_inflow::TimeProfile,
         level_min::TimeProfile,
-        opex_var::TimeProfile,
-        opex_var_pump::TimeProfile,
-        opex_fixed::TimeProfile,
         stor_res::ResourceCarrier,
         input::Dict{<:Resource, <:Real},
         output::Dict{<:Resource, <:Real},
-    )
-    return PumpedHydroStor(
+    ) where {T<:EMB.StorageBehavior}
+    return PumpedHydroStor{T}(
         id,
-        rate_cap,
-        stor_cap,
+        charge,
+        level,
+        discharge,
         level_init,
         level_inflow,
         level_min,
-        opex_var,
-        opex_var_pump,
-        opex_fixed,
         stor_res,
         input,
         output,

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -53,12 +53,13 @@ except for water inflow from outside the model, although it requires a field `in
 - **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `HydroStor` node.
   Depending on the chosen type, the discharge parameters can include variable OPEX, fixed OPEX,
   and/or a capacity.
-- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.
-- **`level_inflow::TimeProfile`** Inflow of power per operational period.
-- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.
+- **`level_init::TimeProfile`** is the initial stored energy in the dam.
+- **`level_inflow::TimeProfile`** is the inflow of power per operational period.
+- **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
+  has to remain in the `HydroStorage` node.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.
-- **`input::Dict{Resource, Real}`** the input `Resource`s. In the case of a `HydroStor`, this
-  can be provided as an empty dictionary `Dict{Resource, Real}()`.
+- **`input::Dict{Resource, Real}`** are the input `Resource`s. In the case of a `HydroStor`,
+  this field can be left out.
 - **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
 - **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
   conditional through usage of a constructor.
@@ -176,12 +177,12 @@ account for the potential to store energy in the form of potential energy.
 - **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `HydroStor` node.
   Depending on the chosen type, the discharge parameters can include variable OPEX, fixed OPEX,
   and/or a capacity.
-- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.
-- **`level_inflow::TimeProfile`** Inflow of power per operational period.
-- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.
+- **`level_init::TimeProfile`** is the initial stored energy in the dam.
+- **`level_inflow::TimeProfile`** is the inflow of power per operational period.
+- **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
+  has to remain in the `HydroStorage` node.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.
-- **`input::Dict{Resource, Real}`** the input `Resource`s. In the case of a `HydroStor`, this
-  can be provided as an empty dictionary `Dict{Resource, Real}()`.
+- **`input::Dict{Resource, Real}`** are the input `Resource`s.
 - **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
 - **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
   conditional through usage of a constructor.

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -1,16 +1,20 @@
-""" A non-dispatchable renewable energy source.
+"""
+    NonDisRES <: EMB.Source
+
+A non-dispatchable renewable energy source. It extends the existing `RefSource` node through
+including a profile that corresponds to thr production. The profile can have variations on
+the strategic level.
 
 # Fields
-- **`id`** is the name/identifyer of the node.\n
-- **`cap::TimeProfile`** is the installed capacity.\n
-- **`profile::TimeProfile`** is the power production in each operational period as a ratio \
-of the installed capacity at that time.\n
-- **`opex_var::TimeProfile`** is the variational operational costs per energy unit produced.\n
-- **`opex_fixed::TimeProfile`** is the fixed operational costs.\n
-- **`output::Dict{Resource, Real}`** are the generated `Resource`s, normally Power.\n
-- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
-`data` is conditional through usage of a constructor.
-
+- **`id`** is the name/identifyer of the node.
+- **`cap::TimeProfile`** is the installed capacity.
+- **`profile::TimeProfile`** is the power production in each operational period as a ratio
+  of the installed capacity at that time.
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit produced.
+- **`opex_fixed::TimeProfile`** is the fixed operating expense.
+- **`output::Dict{Resource, Real}`** are the generated `Resource`s, normally Power.
+- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field `data`
+  is conditional through usage of a constructor.
 """
 struct NonDisRES <: EMB.Source
     id::Any
@@ -35,21 +39,29 @@ end
 """ An abstract type for hydro storage nodes, with or without pumping. """
 abstract type HydroStorage{T} <: EMB.Storage{T} end
 
-""" A regulated hydropower storage, modelled as a `Storage` node.
+"""
+    HydroStor{T} <: HydroStorage{T}
+
+A regulated hydropower storage, modelled as a `Storage` node. A regulated hydro storage node
+requires a capacity for the `discharge` and does not have a required inflow from the model,
+except for water inflow from outside the model, although it requires a field `input`.
 
 ## Fields
-- **`id`** is the name/identifyer of the node.\n
-- **`rate_cap::TimeProfile`**: installed capacity.\n
-- **`stor_cap::TimeProfile`** Initial installed storage capacity in the dam.\n
-- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.\n
-- **`level_inflow::TimeProfile`** Inflow of power per operational period.\n
-- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.\n
-- **`stor_res::ResourceCarrier`** is the stored `Resource`.\n
-- **`input::Dict{Resource, Real}`** the stored and used resources. The \
-values in the Dict is a ratio describing the energy loss when using the pumps.\n
-- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.\n
-- **`data::Vector{Data}`** additional data (e.g. for investments). The field \
-`data` is conditional through usage of a constructor.
+- **`id`** is the name/identifyer of the node.
+- **`level::EMB.UnionCapacity`** are the level parameters of the `HydroStor` node.
+  Depending on the chosen type, the charge parameters can include variable OPEX and/or fixed OPEX.
+- **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `HydroStor` node.
+  Depending on the chosen type, the discharge parameters can include variable OPEX, fixed OPEX,
+  and/or a capacity.
+- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.
+- **`level_inflow::TimeProfile`** Inflow of power per operational period.
+- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** the input `Resource`s. In the case of a `HydroStor`, this
+  can be provided as an empty dictionary `Dict{Resource, Real}()`.
+- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
+- **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
+  conditional through usage of a constructor.
 """
 struct HydroStor{T} <: HydroStorage{T}
     id::Any
@@ -69,9 +81,62 @@ function HydroStor{T}(
         id::Any,
         level::EMB.UnionCapacity,
         discharge::EMB.UnionCapacity,
+
         level_init::TimeProfile,
         level_inflow::TimeProfile,
         level_min::TimeProfile,
+
+        stor_res::ResourceCarrier,
+        output::Dict{<:Resource, <:Real},
+        data::Vector{Data},
+    ) where {T<:EMB.StorageBehavior}
+    return HydroStor{T}(
+        id,
+        level,
+        discharge,
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        Dict{Resource,Real}(stor_res => 1),
+        output,
+        data,
+    )
+end
+function HydroStor{T}(
+        id::Any,
+        level::EMB.UnionCapacity,
+        discharge::EMB.UnionCapacity,
+
+        level_init::TimeProfile,
+        level_inflow::TimeProfile,
+        level_min::TimeProfile,
+
+        stor_res::ResourceCarrier,
+        output::Dict{<:Resource, <:Real},
+    ) where {T<:EMB.StorageBehavior}
+    return HydroStor{T}(
+        id,
+        level,
+        discharge,
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        Dict{Resource,Real}(stor_res => 1),
+        output,
+        Data[],
+    )
+end
+function HydroStor{T}(
+        id::Any,
+        level::EMB.UnionCapacity,
+        discharge::EMB.UnionCapacity,
+
+        level_init::TimeProfile,
+        level_inflow::TimeProfile,
+        level_min::TimeProfile,
+
         stor_res::ResourceCarrier,
         input::Dict{<:Resource, <:Real},
         output::Dict{<:Resource, <:Real},
@@ -90,21 +155,36 @@ function HydroStor{T}(
     )
 end
 
-""" A regulated hydropower storage with pumping capabilities, modelled as a `Storage` node.
+"""
+    PumpedHydroStor{T} <: HydroStorage{T}
+
+A pumped hydropower storage, modelled as a `Storage` node. A pumped hydro storage node
+allows for storing energy through pumping water into the reservoir. The current
+implementation is a simplified node in which no lower reservoir is required. Instead, it is
+assumed that the reservoir has an infinite size.
+
+A pumped hydro storage node requires a capacity for both `charge` and `discharge` to
+account for the potential to store energy in the form of potential energy.
 
 ## Fields
-- **`id`** is the name/identifyer of the node.\n
-- **`rate_cap::TimeProfile`**: installed capacity.\n
-- **`stor_cap::TimeProfile`** Initial installed storage capacity in the dam.\n
-- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.\n
-- **`level_inflow::TimeProfile`** Inflow of power per operational period.\n
-- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.\n
-- **`stor_res::ResourceCarrier`** is the stored `Resource`.\n
-- **`input::Dict{Resource, Real}`** the stored and used resources. The \
-values in the Dict is a ratio describing the energy loss when using the pumps.\n
-- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.\n
-- **`data::Vector{Data}`** additional data (e.g. for investments). The field \
-`data` is conditional through usage of a constructor.\n
+- **`id`** is the name/identifyer of the node.
+- **`charge::EMB.UnionCapacity`** are the charging parameters of the `PumpedHydroStor` node.
+  Depending on the chosen type, the charge parameters can include variable OPEX, fixed OPEX,
+  and/or a capacity.
+- **`level::EMB.UnionCapacity`** are the level parameters of the `HydroStor` node.
+  Depending on the chosen type, the charge parameters can include variable OPEX and/or fixed OPEX.
+- **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `HydroStor` node.
+  Depending on the chosen type, the discharge parameters can include variable OPEX, fixed OPEX,
+  and/or a capacity.
+- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.
+- **`level_inflow::TimeProfile`** Inflow of power per operational period.
+- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** the input `Resource`s. In the case of a `HydroStor`, this
+  can be provided as an empty dictionary `Dict{Resource, Real}()`.
+- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
+- **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
+  conditional through usage of a constructor.
 """
 struct PumpedHydroStor{T} <: HydroStorage{T}
     id::Any

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -1,26 +1,45 @@
 """
-Legacy constructor for a regulated hydropower storage, with or without pumping \
-capabilities. This version will be discontinued in the near future and is already replaced \
-with the two new types `HydroStor` and `PumpedHydroStor`.
+    RegHydroStor(
+        id::Any,
+        rate_cap::TimeProfile,
+        stor_cap::TimeProfile,
+        has_pump::Bool,
+        level_init::TimeProfile,
+        level_inflow::TimeProfile,
+        level_min::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        stor_res::ResourceCarrier,
+        input,
+        output,
+        Data,
+    )
 
-If you are creating a new model, it is advised to directly use the types `HydroStor` and \
-`PumpedHydroStor`.
+Original Legacy constructor for a regulated hydropower storage, with or without pumping capabilities.
+This version is discontinued starting with Version 0.6.0. resulting in an error
+It is replaced with the two new types [`HydroStor`](@ref) and [`PumpedHydroStor`](@ref)
+to utilize the concept of multiple dispatch instead of logic.
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x)*
+for further information regarding how you can translate your existing model to the new model.
 
 ## Fields
-- **`id`** is the name/identifyer of the node.\n
-- **`rate_cap::TimeProfile`**: installed capacity.\n
-- **`stor_cap::TimeProfile`** Initial installed storage capacity in the dam.\n
-- **`has_pump::Bool`** states wheter the stored resource can flow in.\n
-- **`level_init::TimeProfile`** Initial energy stored in the dam, in units of power.\n
-- **`level_inflow::TimeProfile`** Inflow of power per operational period.\n
-- **`level_min::TimeProfile`** Minimum fraction of the reservoir capacity that can be left.\n
-- **`opex_var::TimeProfile`** Operational cost per GWh produced.\n
-- **`opex_fixed::TimeProfile`** Fixed operational costs.\n
-- **`stor_res::ResourceCarrier`** is the stored `Resource`.\n
-- **`input::Dict{Resource, Real}`** the stored and used resources. The \
-values in the Dict is a ratio describing the energy loss when using the pumps.\n
-- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.\n
-- **`data::Array{Data}`** additional data (e.g. for investments).\n
+- **`id`** is the name/identifyer of the node.
+- **`rate_cap::TimeProfile`** is the installed installed rate capacity.
+- **`stor_cap::TimeProfile`** is the installed storage capacity in the dam.
+- **`has_pump::Bool`** states wheter the stored resource can flow in.
+- **`level_init::TimeProfile`** is the initial stored energy in the dam.
+- **`level_inflow::TimeProfile`** is the inflow of power per operational period.
+- **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
+  has to remain in the `HydroStorage` node.
+- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
+- **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** are the stored and used resources. The values in the Dict
+  are ratios describing the energy loss when using the pumps.
+- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
+- **`data::Array{Data}`** additional data (e.g. for investments). This value is conditional
+  through the application of a constructor.
 """
 function RegHydroStor(
     id::Any,
@@ -37,48 +56,59 @@ function RegHydroStor(
     output,
     Data,
 )
-    @warn(
-        "This implementation of a `RegHydroStor` will be discontinued in the near future. \n
+    @error(
+        "This implementation of a `RegHydroStor` will be discontinued in the near future.
         It is replaced with the type
             - `PumpedHydroStor` when considering a pumped hydro storage node or
             - `HydroStor` for a standard regulated hydro power plant.
         You can find the individual fields of these types in the documentation."
     )
-
-    if has_pump
-        return PumpedHydroStor(
-            id,
-            rate_cap,
-            stor_cap,
-            level_init,
-            level_inflow,
-            level_min,
-            FixedProfile(0),
-            opex_var,
-            opex_fixed,
-            stor_res,
-            input,
-            output,
-            Data,
-        )
-    else
-        return HydroStor(
-            id,
-            rate_cap,
-            stor_cap,
-            level_init,
-            level_inflow,
-            level_min,
-            opex_fixed,
-            stor_res,
-            input,
-            output,
-            Data,
-        )
-    end
 end
 
+"""
+    HydroStor(
+        id::Any,
+        rate_cap::TimeProfile,
+        stor_cap::TimeProfile,
+        level_init::TimeProfile,
+        level_inflow::TimeProfile,
+        level_min::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        stor_res::ResourceCarrier,
+        input,
+        output,
+        Data,
+    )
 
+Legacy constructor for a regulated hydropower plant without pumping capabilities.
+This version will be discontinued in the near future and replaced with the new version of
+`HydroStor{StorageBehavior}` in which the parametric input defines the behavior of the
+hydropower plant.
+In addition, the introduction of `AbstractStorageParameters` allows for an improved
+description of the individual capacities and OPEX contributions for the storage `level` and
+`discharge` capacity.
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x)*
+for further information regarding how you can translate your existing model to the new model.
+
+## Fields
+- **`id`** is the name/identifyer of the node.
+- **`rate_cap::TimeProfile`** is the installed installed rate capacity.
+- **`stor_cap::TimeProfile`** is the installed storage capacity in the dam.
+- **`level_init::TimeProfile`** is the initial stored energy in the dam.
+- **`level_inflow::TimeProfile`** is the inflow of power per operational period.
+- **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
+  has to remain in the `HydroStorage` node.
+- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
+- **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** are the stored and used resources. The values in the Dict
+  are ratios describing the energy loss when using the pumps.
+- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
+- **`data::Array{Data}`** additional data (e.g. for investments). This value is conditional
+  through the application of a constructor.
+"""
 function HydroStor(
     id,
     rate_cap::TimeProfile,
@@ -94,6 +124,19 @@ function HydroStor(
     input::Dict{<:Resource, <:Real},
     output::Dict{<:Resource, <:Real},
 )
+    @warn(
+        "The used implementation of a `HydroStor` will be discontinued in the near " *
+        "future. The new implementation using the types the types `StorageBehavior` and " *
+        "`AbstractStorageParameters` for describing a) the cyclic behavior and b) " *
+        "the parameters for the `level` and `discharge` capacities.\n" *
+        "In practice, two changes have to be incorporated: \n 1. `HydroStor{CyclicStrategic}()` " *
+        "instead of `HydroStor` and \n 2. the application of `StorCapOpexFixed(stor_cap, opex_fixed)` " *
+        "as 2ⁿᵈ field as well as `StorCapOpexVar(rate_cap, opex_var))` as 3ʳᵈ field. " *
+        "2ⁿᵈ, 3ʳᵈ, 7ᵗʰ and 8ᵗʰ fields are removed.\n" *
+        "See the documentation (https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x) " *
+        "on how to update your model to the latest version.",
+        maxlog = 1
+    )
 
     return HydroStor{CyclicStrategic}(
         id,
@@ -124,6 +167,19 @@ function HydroStor(
     output::Dict{<:Resource, <:Real},
     data::Vector{Data},
 )
+    @warn(
+        "The used implementation of a `HydroStor` will be discontinued in the near " *
+        "future. The new implementation using the types the types `StorageBehavior` and " *
+        "`AbstractStorageParameters` for describing a) the cyclic behavior and b) " *
+        "the parameters for the `level` and `discharge` capacities.\n" *
+        "In practice, two changes have to be incorporated: \n 1. `HydroStor{CyclicStrategic}()` " *
+        "instead of `HydroStor` and \n 2. the application of `StorCapOpexFixed(stor_cap, opex_fixed)` " *
+        "as 2ⁿᵈ field as well as `StorCapOpexVar(rate_cap, opex_var))` as 3ʳᵈ field. " *
+        "2ⁿᵈ, 3ʳᵈ, 7ᵗʰ and 8ᵗʰ fields are removed.\n" *
+        "See the documentation (https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x) " *
+        "on how to update your model to the latest version.",
+        maxlog = 1
+    )
 
     return HydroStor{CyclicStrategic}(
         id,
@@ -139,6 +195,52 @@ function HydroStor(
     )
 end
 
+"""
+    PumpedHydroStor(
+        id::Any,
+        rate_cap::TimeProfile,
+        stor_cap::TimeProfile,
+        level_init::TimeProfile,
+        level_inflow::TimeProfile,
+        level_min::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        stor_res::ResourceCarrier,
+        input,
+        output,
+        Data,
+    )
+
+Legacy constructor for a regulated  pumped hydropower storage plant.
+This version will be discontinued in the near future and replaced with the new version of
+`HydroStor{StorageBehavior}` in which the parametric input defines the behavior of the
+hydropower plant.
+In addition, the introduction of `AbstractStorageParameters` allows for an improved
+description of the individual capacities and OPEX contributions for the pump capacity
+(`charge`), storage `level` and `discharge` capacity.
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x)*
+for further information regarding how you can translate your existing model to the new model.
+
+## Fields
+- **`id`** is the name/identifyer of the node.
+- **`rate_cap::TimeProfile`** is the installed installed rate capacity.
+- **`stor_cap::TimeProfile`** is the installed storage capacity in the dam.
+- **`level_init::TimeProfile`** is the initial stored energy in the dam.
+- **`level_inflow::TimeProfile`** is the inflow of power per operational period.
+- **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
+  has to remain in the `HydroStorage` node.
+- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
+- **`opex_var_pump::TimeProfile`** are the variable operational expenses per GWh pumped
+  into the storage.
+- **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** are the stored and used resources. The values in the Dict
+  are ratios describing the energy loss when using the pumps.
+- **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
+- **`data::Array{Data}`** additional data (e.g. for investments). This value is conditional
+  through the application of a constructor.
+"""
 function PumpedHydroStor(
     id,
     rate_cap::TimeProfile,
@@ -155,6 +257,20 @@ function PumpedHydroStor(
     input::Dict{<:Resource, <:Real},
     output::Dict{<:Resource, <:Real},
 )
+    @warn(
+        "The used implementation of a `PumpedHydroStor` will be discontinued in the near " *
+        "future. The new implementation using the types the types `StorageBehavior` and " *
+        "`AbstractStorageParameters` for describing a) the cyclic behavior and b) " *
+        "the parameters for the `level`, `charge`, and `discharge` capacities.\n" *
+        "In practice, two changes have to be incorporated: \n 1. `PumpedHydroStor{CyclicStrategic}()` " *
+        "instead of `PumpedHydroStor` and \n 2. the application of `StorCapOpexVar(rate_cap, opex_var_pump)` " *
+        "as 2ⁿᵈ field, `StorCapOpexFixed(stor_cap, opex_fixed)` as 3ʳᵈ field, and" *
+        "`StorCapOpexVar(rate_cap, opex_var))` as 4ᵗʰ field. " *
+        "The previous 2ⁿᵈ, 3ʳᵈ, 7ᵗʰ, 8ᵗʰ, and 9ᵗʰ fields are removed.\n" *
+        "See the documentation (https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x) " *
+        "on how to update your model to the latest version.",
+        maxlog = 1
+    )
 
     return PumpedHydroStor{CyclicStrategic}(
         id,
@@ -170,7 +286,6 @@ function PumpedHydroStor(
         Data[],
     )
 end
-
 function PumpedHydroStor(
     id,
     rate_cap::TimeProfile,
@@ -188,6 +303,20 @@ function PumpedHydroStor(
     output::Dict{<:Resource, <:Real},
     data::Vector{Data},
 )
+    @warn(
+        "The used implementation of a `PumpedHydroStor` will be discontinued in the near " *
+        "future. The new implementation using the types the types `StorageBehavior` and " *
+        "`AbstractStorageParameters` for describing a) the cyclic behavior and b) " *
+        "the parameters for the `level`, `charge`, and `discharge` capacities.\n" *
+        "In practice, two changes have to be incorporated: \n 1. `PumpedHydroStor{CyclicStrategic}()` " *
+        "instead of `PumpedHydroStor` and \n 2. the application of `StorCapOpexVar(rate_cap, opex_var_pump)` " *
+        "as 2ⁿᵈ field, `StorCapOpexFixed(stor_cap, opex_fixed)` as 3ʳᵈ field, and" *
+        "`StorCapOpexVar(rate_cap, opex_var))` as 4ᵗʰ field. " *
+        "The previous 2ⁿᵈ, 3ʳᵈ, 7ᵗʰ, 8ᵗʰ, and 9ᵗʰ fields are removed.\n" *
+        "See the documentation (https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/how-to/update-models/#Adjustments-from-0.4.0-to-0.6.x) " *
+        "on how to update your model to the latest version.",
+        maxlog = 1
+    )
 
     return PumpedHydroStor{CyclicStrategic}(
         id,

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -69,7 +69,6 @@ function RegHydroStor(
             level_init,
             level_inflow,
             level_min,
-            FixedProfile(0),
             opex_fixed,
             stor_res,
             input,
@@ -77,4 +76,97 @@ function RegHydroStor(
             Data,
         )
     end
+end
+
+
+function HydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+    Data,
+)
+
+    return HydroStor{CyclicStrategic}(
+        id,
+        StorCap(stor_cap),
+        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        input,
+        output,
+        Data,
+    )
+end
+function HydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+)
+
+    return HydroStor{CyclicStrategic}(
+        id,
+        StorCap(stor_cap),
+        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        input,
+        output,
+        Data[],
+    )
+end
+
+function PumpedHydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_var_pump::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+)
+
+    return PumpedHydroStor{CyclicStrategic}(
+        id,
+        StorCapOpexVar(rate_cap, opex_var_pump),
+        StorCap(stor_cap),
+        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        input,
+        output,
+        Data[],
+    )
 end

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -93,20 +93,19 @@ function HydroStor(
     stor_res::ResourceCarrier,
     input::Dict{<:Resource, <:Real},
     output::Dict{<:Resource, <:Real},
-    Data,
 )
 
     return HydroStor{CyclicStrategic}(
         id,
-        StorCap(stor_cap),
-        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        StorCapOpexFixed(stor_cap, opex_fixed),
+        StorCapOpexVar(rate_cap, opex_var),
         level_init,
         level_inflow,
         level_min,
         stor_res,
         input,
         output,
-        Data,
+        Data[],
     )
 end
 function HydroStor(
@@ -123,12 +122,45 @@ function HydroStor(
     stor_res::ResourceCarrier,
     input::Dict{<:Resource, <:Real},
     output::Dict{<:Resource, <:Real},
+    data::Vector{Data},
 )
 
     return HydroStor{CyclicStrategic}(
         id,
-        StorCap(stor_cap),
-        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        StorCapOpexFixed(stor_cap, opex_fixed),
+        StorCapOpexVar(rate_cap, opex_var),
+        level_init,
+        level_inflow,
+        level_min,
+        stor_res,
+        input,
+        output,
+        data,
+    )
+end
+
+function PumpedHydroStor(
+    id,
+    rate_cap::TimeProfile,
+    stor_cap::TimeProfile,
+
+    level_init::TimeProfile,
+    level_inflow::TimeProfile,
+    level_min::TimeProfile,
+
+    opex_var::TimeProfile,
+    opex_var_pump::TimeProfile,
+    opex_fixed::TimeProfile,
+    stor_res::ResourceCarrier,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+)
+
+    return PumpedHydroStor{CyclicStrategic}(
+        id,
+        StorCapOpexVar(rate_cap, opex_var_pump),
+        StorCapOpexFixed(stor_cap, opex_fixed),
+        StorCapOpexVar(rate_cap, opex_var),
         level_init,
         level_inflow,
         level_min,
@@ -154,19 +186,20 @@ function PumpedHydroStor(
     stor_res::ResourceCarrier,
     input::Dict{<:Resource, <:Real},
     output::Dict{<:Resource, <:Real},
+    data::Vector{Data},
 )
 
     return PumpedHydroStor{CyclicStrategic}(
         id,
         StorCapOpexVar(rate_cap, opex_var_pump),
-        StorCap(stor_cap),
-        StorCapOpex(rate_cap, opex_var, opex_fixed),
+        StorCapOpexFixed(stor_cap, opex_fixed),
+        StorCapOpexVar(rate_cap, opex_var),
         level_init,
         level_inflow,
         level_min,
         stor_res,
         input,
         output,
-        Data[],
+        data,
     )
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -12,13 +12,13 @@ end
 # method defined for a general Source node, which is located in EnergyModelsBase.
 
 """
-    EMB.variables_node(m, 𝒩::Vector{HydroStorage}, 𝒯, modeltype::EnergyModel)
+    EMB.variables_node(m, 𝒩::Vector{<:HydroStorage}, 𝒯, modeltype::EnergyModel)
 
 Create the optimization variable `:hydro_spill` for every HydroStorage node. This variable
 enables hydro storage nodes to spill water from the reservoir without producing energy.
 Wihtout this slack variable, parameters with too much inflow would else lead to an
 infeasible model. """
-function EMB.variables_node(m, 𝒩::Vector{HydroStorage}, 𝒯, modeltype::EnergyModel)
+function EMB.variables_node(m, 𝒩::Vector{<:HydroStorage}, 𝒯, modeltype::EnergyModel)
     @variable(m, hydro_spill[𝒩, 𝒯] >= 0)
 end
 
@@ -45,18 +45,18 @@ function EMB.create_node(m, n::HydroStorage, 𝒯, 𝒫, modeltype::EnergyModel)
     @constraint(
         m,
         [t ∈ 𝒯],
-        m[:flow_out][n, t, p_stor] == m[:stor_rate_use][n, t] * outputs(n, p_stor)
+        m[:flow_out][n, t, p_stor] == m[:stor_discharge_use][n, t] * outputs(n, p_stor)
     )
 
     # Can not produce more energy than what is availbable in the reservoir.
-    @constraint(m, [t ∈ 𝒯], m[:stor_rate_use][n, t] <= m[:stor_level][n, t])
+    @constraint(m, [t ∈ 𝒯], m[:stor_discharge_use][n, t] <= m[:stor_level][n, t])
 
     # The minimum contents of the reservoir is bounded below. Not allowed
     # to drain it completely.
     @constraint(
         m,
         [t ∈ 𝒯],
-        m[:stor_level][n, t] ≥ level_min(n, t) * m[:stor_cap_inst][n, t]
+        m[:stor_level][n, t] ≥ level_min(n, t) * m[:stor_level_inst][n, t]
     )
 
     # Iterate through all data and set up the constraints corresponding to the data

--- a/src/model.jl
+++ b/src/model.jl
@@ -33,13 +33,11 @@ function EMB.create_node(m, n::HydroStorage, 𝒯, 𝒫, modeltype::EnergyModel)
     p_stor = EMB.storage_resource(n)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    # If the reservoir has no pump, the stored resource cannot flow in.
-    if isa(n, HydroStor)
-        @constraint(m, [t ∈ 𝒯], m[:flow_in][n, t, p_stor] == 0)
-    end
-
     # Energy balance constraints for stored electricity.
     constraints_level(m, n, 𝒯, 𝒫, modeltype)
+
+    # Call of the function for the inlet flow to the `HydroStorage` node
+    constraints_flow_in(m, n, 𝒯, modeltype)
 
     # The flow_out is equal to the production stor_rate_use.
     @constraint(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ const EMRP = EnergyModelsRenewableProducers
     include("test_nondisres.jl")
     include("test_hydro.jl")
     include("test_examples.jl")
+    include("test_constructors.jl")
 end

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -1,0 +1,318 @@
+@testset "Legacy constructors" begin
+
+    # Used parameters
+    rate_cap = FixedProfile(2.0)
+    stor_cap = FixedProfile(40)
+
+    level_init = StrategicProfile([20, 25, 30, 20])
+    level_inflow = FixedProfile(10)
+    level_min = StrategicProfile([0.1, 0.2, 0.05, 0.1])
+
+    opex_var = FixedProfile(10)
+    opex_var_pump = FixedProfile(10)
+    opex_fixed = FixedProfile(10)
+
+    stor_res = Power
+    input = Dict(Power => 0.9)
+    output = Dict(Power => 1)
+
+    data = Data[]
+
+    # Check that `Hydrostor` nodes are correctly constructed
+    @testset "Hydrostor node wo data" begin
+        hydro_old = HydroStor(
+            "hydro",
+            rate_cap,
+            stor_cap,
+            level_init,
+            level_inflow,
+            level_min,
+            opex_var,
+            opex_fixed,
+            stor_res,
+            input,
+            output,
+        )
+
+        hydro_new = HydroStor{CyclicStrategic}(
+            "hydro",
+            StorCapOpexFixed(stor_cap, opex_fixed),
+            StorCapOpexVar(rate_cap, opex_var),
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            Data[],
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+    @testset "Hydrostor node with data" begin
+        hydro_old = HydroStor(
+            "hydro",
+            rate_cap,
+            stor_cap,
+            level_init,
+            level_inflow,
+            level_min,
+            opex_var,
+            opex_fixed,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+
+        hydro_new = HydroStor{CyclicStrategic}(
+            "hydro",
+            StorCapOpexFixed(stor_cap, opex_fixed),
+            StorCapOpexVar(rate_cap, opex_var),
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+
+
+    # Check that `PumpedHydroStor` nodes are correctly constructed
+    @testset "PumpedHydroStor node wo data" begin
+        hydro_old = PumpedHydroStor(
+            "hydro",
+            rate_cap,
+            stor_cap,
+            level_init,
+            level_inflow,
+            level_min,
+            opex_var,
+            opex_var_pump,
+            opex_fixed,
+            stor_res,
+            input,
+            output,
+        )
+
+        hydro_new = PumpedHydroStor{CyclicStrategic}(
+            "hydro",
+            StorCapOpexVar(rate_cap, opex_var_pump),
+            StorCapOpexFixed(stor_cap, opex_fixed),
+            StorCapOpexVar(rate_cap, opex_var),
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            Data[],
+        )
+        for field ∈ fieldnames(PumpedHydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+    @testset "PumpedHydroStor node with data" begin
+        hydro_old = PumpedHydroStor(
+            "hydro",
+            rate_cap,
+            stor_cap,
+            level_init,
+            level_inflow,
+            level_min,
+            opex_var,
+            opex_var_pump,
+            opex_fixed,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+
+        hydro_new = PumpedHydroStor{CyclicStrategic}(
+            "hydro",
+            StorCapOpexVar(rate_cap, opex_var_pump),
+            StorCapOpexFixed(stor_cap, opex_fixed),
+            StorCapOpexVar(rate_cap, opex_var),
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+        for field ∈ fieldnames(PumpedHydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+end
+
+@testset "Simplified constructors" begin
+
+    # Used parameters
+    charge = StorCapOpex(FixedProfile(5), FixedProfile(1), FixedProfile(50))
+    level = StorCapOpexFixed(FixedProfile(100), FixedProfile(10))
+    discharge = StorCapOpexVar(FixedProfile(2), FixedProfile(1))
+
+    level_init = StrategicProfile([20, 25, 30, 20])
+    level_inflow = FixedProfile(10)
+    level_min = StrategicProfile([0.1, 0.2, 0.05, 0.1])
+
+    opex_var = FixedProfile(10)
+    opex_var_pump = FixedProfile(10)
+    opex_fixed = FixedProfile(10)
+
+    stor_res = Power
+    input = Dict(Power => 0.9)
+    output = Dict(Power => 1)
+
+    data = Data[]
+
+    # Check that `Hydrostor` nodes are correctly constructed when using simplified
+    # constructors
+    @testset "Hydrostor node wo data" begin
+        hydro_old = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+        )
+
+        hydro_new = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+    @testset "Hydrostor node wo input" begin
+        hydro_old = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            output,
+            data,
+        )
+
+        hydro_new = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            Dict{Resource,Real}(stor_res => 1),
+            output,
+            data,
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+
+    end
+    @testset "Hydrostor node wo data and input" begin
+        hydro_old = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            output,
+        )
+
+        hydro_new = HydroStor{CyclicStrategic}(
+            "hydro",
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            Dict{Resource,Real}(stor_res => 1),
+            output,
+            Data[],
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+
+        # Test that an empty input results in a running model
+        case, modeltype = small_graph()
+
+        # Updating the nodes and the links
+        push!(case[:nodes], hydro_new)
+        link_from = EMB.Direct(41, case[:nodes][4], case[:nodes][1], EMB.Linear())
+        push!(case[:links], link_from)
+        link_to = EMB.Direct(14, case[:nodes][1], case[:nodes][4], EMB.Linear())
+        push!(case[:links], link_to)
+
+        # Run the model
+        m = EMB.run_model(case, modeltype, OPTIMIZER)
+
+        # Run of the general and node tests
+        general_tests(m)
+        general_node_tests(m, case, hydro_new)
+    end
+
+    # Check that `PumpedHydroStor` nodes are correctly constructed when using simplified
+    # constructors
+    @testset "PumpedHydroStor node wo data" begin
+        hydro_old = PumpedHydroStor{CyclicStrategic}(
+            "hydro",
+            charge,
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+        )
+
+        hydro_new = PumpedHydroStor{CyclicStrategic}(
+            "hydro",
+            charge,
+            level,
+            discharge,
+            level_init,
+            level_inflow,
+            level_min,
+            stor_res,
+            input,
+            output,
+            data,
+        )
+        for field ∈ fieldnames(HydroStor{CyclicStrategic})
+            @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
+        end
+    end
+end

--- a/test/test_hydro.jl
+++ b/test/test_hydro.jl
@@ -4,20 +4,19 @@ function general_node_tests(m, case, n::EMRP.HydroStorage)
     # Extract time structure and storage node
     𝒯 = case[:T]
     p_stor = EMB.storage_resource(n)
-    cap = EMB.capacity(n)
 
     @testset "stor_level bounds" begin
         # The storage level has to be greater than the required minimum.
         @test sum(
-            EMRP.level_min(n, t) * value.(m[:stor_cap_inst][n, t]) <=
+            EMRP.level_min(n, t) * value.(m[:stor_level_inst][n, t]) <=
             round(value.(m[:stor_level][n, t]), digits = ROUND_DIGITS) for t ∈ 𝒯
         ) == length(𝒯)
 
-        # The stor_level has to be less than stor_cap_inst in all operational periods.
+        # The stor_level has to be less than stor_level_inst in all operational periods.
         @test sum(
-            value.(m[:stor_level][n, t]) <= value.(m[:stor_cap_inst][n, t]) for t ∈ 𝒯
+            value.(m[:stor_level][n, t]) <= value.(m[:stor_level_inst][n, t]) for t ∈ 𝒯
         ) == length(𝒯)
-        # TODO valing Storage node har negativ stor_cap_inst et par steder.
+        # TODO valing Storage node har negativ stor_level_inst et par steder.
         # TODO this is ok when inflow=1. When inflow=10 the stor_level gets too large. Why?
         #  - Do we need some other sink in the system? Not logical to be left with too much power.
 
@@ -26,7 +25,7 @@ function general_node_tests(m, case, n::EMRP.HydroStorage)
         @test sum(
             value.(value.(m[:stor_level_Δ_op][n, t])) ≈
             EMRP.level_inflow(n, t) + inputs(n, p_stor) * value.(m[:flow_in][n, t, p_stor]) -
-            value.(m[:stor_rate_use][n, t]) - value.(m[:hydro_spill][n, t]) for t ∈ 𝒯,
+            value.(m[:stor_discharge_use][n, t]) - value.(m[:hydro_spill][n, t]) for t ∈ 𝒯,
             atol ∈ TEST_ATOL
         ) ≈ length(𝒯) atol = TEST_ATOL
 
@@ -38,12 +37,12 @@ function general_node_tests(m, case, n::EMRP.HydroStorage)
             duration(first(t_inv)) * (
                 EMRP.level_inflow(n, first(t_inv)) +
                 value.(m[:flow_in][n, first(t_inv), p_stor]) -
-                value.(m[:stor_rate_use][n, first(t_inv)]) -
+                value.(m[:stor_discharge_use][n, first(t_inv)]) -
                 value.(m[:hydro_spill][n, first(t_inv)])
             ) for t_inv ∈ strategic_periods(𝒯)
         ) == length(strategic_periods(𝒯))
 
-        # Check that stor_level is correct wrt. previous stor_level, inflow and stor_rate_use.
+        # Check that stor_level is correct wrt. previous stor_level, inflow and stor_discharge_use.
         if 𝒯 isa TwoLevel{T,T,U} where {T,U<:SimpleTimes}
             non_first = 𝒯.len
         else
@@ -55,42 +54,42 @@ function general_node_tests(m, case, n::EMRP.HydroStorage)
             duration(t) * (
                 EMRP.level_inflow(n, t) +
                 inputs(n, p_stor) * value.(m[:flow_in][n, t, p_stor]) -
-                value.(m[:stor_rate_use][n, t]) - value.(m[:hydro_spill][n, t])
+                value.(m[:stor_discharge_use][n, t]) - value.(m[:hydro_spill][n, t])
             ) for t_inv ∈ strategic_periods(𝒯) for
             (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
         ) == length(𝒯) - non_first
     end
 
-    @testset "stor_cap_inst bounds" begin
-        # Assure that the stor_cap_inst variable is non-negative.
-        @test sum(value.(m[:stor_cap_inst][n, t]) >= 0 for t ∈ 𝒯) == length(𝒯)
+    @testset "stor_level_inst bounds" begin
+        # Assure that the stor_level_inst variable is non-negative.
+        @test sum(value.(m[:stor_level_inst][n, t]) >= 0 for t ∈ 𝒯) == length(𝒯)
 
-        # Check that stor_cap_inst is set to cap.level.
-        @test sum(value.(m[:stor_cap_inst][n, t]) == cap.level[t] for t ∈ 𝒯) == length(𝒯)
+        # Check that stor_level_inst is set to cap.level.
+        @test sum(value.(m[:stor_level_inst][n, t]) == capacity(level(n), t) for t ∈ 𝒯) == length(𝒯)
     end
 
-    @testset "stor_rate_use bounds" begin
+    @testset "stor_discharge_use bounds" begin
         # Cannot produce more than what is stored in the reservoir.
         @test sum(
-            value.(m[:stor_rate_use][n, t]) <= value.(m[:stor_level][n, t]) for t ∈ 𝒯
+            value.(m[:stor_discharge_use][n, t]) <= value.(m[:stor_level][n, t]) for t ∈ 𝒯
         ) == length(𝒯)
 
-        # Check that stor_rate_use is bounded above by stor_rate_inst.
+        # Check that stor_discharge_use is bounded above by stor_discharge_inst.
         @test sum(
-            round(value.(m[:stor_rate_use][n, t]), digits = ROUND_DIGITS) <=
-            value.(m[:stor_rate_inst][n, t]) for t ∈ 𝒯
+            round(value.(m[:stor_discharge_use][n, t]), digits = ROUND_DIGITS) <=
+            value.(m[:stor_discharge_inst][n, t]) for t ∈ 𝒯
         ) == length(𝒯)
     end
 
-    @testset "stor_rate_inst" begin
-        @test sum(value.(m[:stor_rate_inst][n, t]) == cap.rate[t] for t ∈ 𝒯) == length(𝒯)
+    @testset "stor_discharge_inst" begin
+        @test sum(value.(m[:stor_discharge_inst][n, t]) == capacity(discharge(n), t) for t ∈ 𝒯) == length(𝒯)
     end
 
     @testset "flow variables" begin
-        # The flow_out corresponds to the production stor_rate_use.
+        # The flow_out corresponds to the production stor_discharge_use.
         @test sum(
             value.(m[:flow_out][n, t, p_stor]) ==
-            value.(m[:stor_rate_use][n, t]) * outputs(n, Power) for t ∈ 𝒯
+            value.(m[:stor_discharge_use][n, t]) * outputs(n, Power) for t ∈ 𝒯
         ) == length(𝒯)
     end
 end
@@ -356,7 +355,7 @@ end
 
                     @test value.(m[:stor_level][n, t]) -
                           value.(m[:stor_level_Δ_op][n, t]) * duration(t) ≤
-                          value.(m[:stor_cap_inst][n, t]) + TEST_ATOL
+                          value.(m[:stor_level_inst][n, t]) + TEST_ATOL
 
                 elseif isnothing(t_prev)
                     # Test for the correct accounting in the first operational period of the
@@ -378,7 +377,7 @@ end
 
                     @test value.(m[:stor_level][n, t]) -
                           value.(m[:stor_level_Δ_op][n, t]) * duration(t) ≤
-                          value.(m[:stor_cap_inst][n, t]) + TEST_ATOL
+                          value.(m[:stor_level_inst][n, t]) + TEST_ATOL
                 end
             end
         end
@@ -395,9 +394,7 @@ end
     products = [Power, CO2]
     source = EMB.RefSource(
         "-source",
-        OperationalProfile([
-            10 10 10 10 10 0 0 0 0 0
-        ]),
+        OperationalProfile([10, 10, 10, 10, 10, 0, 0, 0, 0, 0]),
         FixedProfile(10),
         FixedProfile(10),
         Dict(Power => 1),

--- a/test/test_hydro.jl
+++ b/test/test_hydro.jl
@@ -329,6 +329,9 @@ end
         general_tests(m)
         general_node_tests(m, case, hydro1)
 
+        # Test the objective value
+        @test objective_value(m) ≈ -116160.0
+
         # All the tests following er for the function
         # - constraints_level(m, n::HydroStorage, 𝒯, 𝒫, modeltype::EnergyModel)
         for t_inv ∈ 𝒯ᴵⁿᵛ
@@ -403,7 +406,7 @@ end
     sink = EMB.RefSink(
         "-sink",
         FixedProfile(7),
-        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e2)),
         Dict(Power => 1),
     )
 
@@ -419,7 +422,7 @@ end
         initial_reservoir,
         FixedProfile(1),
         min_level,
-        FixedProfile(0),
+        FixedProfile(5),
         FixedProfile(30),
         FixedProfile(10),
         Power,
@@ -434,7 +437,7 @@ end
     link_to = EMB.Direct(14, case[:nodes][1], case[:nodes][4], EMB.Linear())
     push!(case[:links], link_to)
 
-    case[:T] = TwoLevel(2, 1, SimpleTimes(10, 1))
+    case[:T] = TwoLevel(2, 1, SimpleTimes(10, 1); op_per_strat=10)
 
     # Run the model
     m = EMB.run_model(case, modeltype, OPTIMIZER; check_timeprofiles=false)
@@ -445,6 +448,9 @@ end
     # Run of the general and node tests
     general_tests(m)
     general_node_tests(m, case, hydro)
+
+    # Test the objective value
+    @test objective_value(m) ≈ -6825.0
 
     @testset "flow_in" begin
         # Check that the zero equality constraint is not set on the flow_in variable

--- a/test/test_hydro.jl
+++ b/test/test_hydro.jl
@@ -210,7 +210,7 @@ end
 
     # Test that the fields of a HydroStor are correctly checked
     # - check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel)
-    # check_node(HydroStor)
+    check_node(HydroStor)
 
     # Creation of the initial problem and the HydroStor node
     max_storage = FixedProfile(100)
@@ -368,7 +368,7 @@ end
 
     # Test that the fields of a PumpedHydroStor are correctly checked
     # - check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel)
-    # check_node(PumpedHydroStor)
+    check_node(PumpedHydroStor)
 
     # Creation of the initial problem and the PumpedHydroStor node with a pump.
     products = [Power, CO2]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -13,7 +13,7 @@ function small_graph(; source = nothing, sink = nothing, ops = SimpleTimes(24, 2
     if isnothing(source)
         source = RefSource(
             2,
-            FixedProfile(1),
+            FixedProfile(20),
             FixedProfile(30),
             FixedProfile(10),
             Dict(Power => 1),


### PR DESCRIPTION
`EnergyModelsBase` v0.7 changed how `Storage` nodes are handled through the introduction of a [`StorageBehaviour`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/26) and [`AbstractStorageParameter`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/29).

As a consequence, we had to update `EMRP` to support the new structures.
This PR closes [Issue 17](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/issues/17).

@hellemo : Do you think the changes warrant an increase to 0.6 or is 0.5.7 sufficient? It includes most likely breaking changes for node development, but not for application through the introduction of the constructors. In practice, other packages should not depend on EMRP. Hence, I would argue that 0.5.7 should be ok.

Draft status until we decided version increase and I updated the NEWS.md