### PR TITLE
Feature/AbstractNonDisRES

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.6.2 (2024-09-03)
+## Version 0.6.2 (2024-10-16)
 
 * Minor updates on docstrings and descriptions.
 * Adjusted to [`EnergyModelsBase` v0.8.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.8.1).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # Release notes
 
-## Unversioned
+## Version 0.6.2 (2024-09-03)
 
 * Minor updates on docstrings and descriptions.
 * Adjusted to [`EnergyModelsBase` v0.8.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.8.1).
+* Introduced abstract supertype `AbstractNonDisRES` for `NonDisRES` to allow for other implementations that use as well the variable `curtailement`.
 
 ## Version 0.6.1 (2024-09-03)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Minor updates on docstrings and descriptions.
 * Adjusted to [`EnergyModelsBase` v0.8.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.8.1).
-* Introduced abstract supertype `AbstractNonDisRES` for `NonDisRES` to allow for other implementations that use as well the variable `curtailement`.
+* Introduced abstract supertype `AbstractNonDisRES` for `NonDisRES` to allow for other implementations that use as well the variable `curtailment`.
 
 ## Version 0.6.1 (2024-09-03)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRenewableProducers"
 uuid = "b007c34f-ba52-4995-ba37-fffe79fbde35"
 authors = ["Sigmund Eggen Holm <Sigmund.Holm@sintef.no>, Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -12,6 +12,7 @@ EnergyModelsRenewableProducers
 
 ```@docs
 HydroStorage
+AbstractNonDisRES
 ```
 
 ### [Concrete types](@id lib-pub-node-concrete)

--- a/docs/src/nodes/nondisres.md
+++ b/docs/src/nodes/nondisres.md
@@ -8,7 +8,12 @@ As a consequence, the design of the [`RefSource`](@extref EnergyModelsBase.RefSo
 
 Hence, it is necessary to implement a source node representing intermittent renewable energy generation.
 
-## [Introduced type and its fields](@id nodes-nondisres-fields)
+!!! note "Abstract supertype"
+    We implemented an abstract supertype [`AbstractNonDisRES`](@ref).
+    This supertype is used for introducing the variable ``\texttt{curtailment}[n, t]`` and updateing the capacity constraints.
+    Hence, if you plan to create a new non-dispatchable renewable energy source, you can create it as subtype of `AbstractNonDisRES`, resulting in the variable being available.
+
+## [Introduced type and its field](@id nodes-nondisres-fields)
 
 The [`NonDisRES`](@ref) is implemented as equivalent to a [`RefSource`](@extref EnergyModelsBase.RefSource).
 Hence, it utilizes the same functions declared in `EnergyModelsBase`.

--- a/src/EnergyModelsRenewableProducers.jl
+++ b/src/EnergyModelsRenewableProducers.jl
@@ -26,7 +26,7 @@ include("constraint_functions.jl")
 # Legacy constructors for node types
 include("legacy_constructor.jl")
 
-export NonDisRES
+export AbstractNonDisRES, NonDisRES
 export HydroStorage, RegHydroStor, HydroStor, PumpedHydroStor
 
 end # module

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -1,12 +1,12 @@
 #! format: off
 
 """
-    constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
+    constraints_capacity(m, n::AbstractNonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
 
-Function for creating the constraint on the maximum capacity of a `NonDisRES`.
+Function for creating the constraint on the maximum capacity of a `AbstractNonDisRES`.
 Also sets the constraint defining curtailment.
 """
-function EMB.constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
+function EMB.constraints_capacity(m, n::AbstractNonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
     @constraint(m, [t ∈ 𝒯],
         m[:cap_use][n, t] ≤ m[:cap_inst][n, t]
     )

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -1,8 +1,15 @@
 """
-    NonDisRES <: EMB.Source
+    abstract type AbstractNonDisRES <: EMB.Source
+
+Abstract supertype for all non-dispatchable renewable energy source. All functions for the
+implemented version of the [`NonDisRES`](@ref) are dispatching on this supertype.
+"""
+abstract type AbstractNonDisRES <: EMB.Source end
+"""
+    NonDisRES <: AbstractNonDisRES
 
 A non-dispatchable renewable energy source. It extends the existing `RefSource` node through
-including a profile that corresponds to thr production. The profile can have variations on
+including a profile that corresponds to the production. The profile can have variations on
 the strategic level.
 
 # Fields
@@ -16,7 +23,7 @@ the strategic level.
 - **`data::Vector{Data}`** is the additional data (e.g. for investments). The field `data`
   is conditional through usage of a constructor.
 """
-struct NonDisRES <: EMB.Source
+struct NonDisRES <: AbstractNonDisRES
     id::Any
     cap::TimeProfile
     profile::TimeProfile

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -44,14 +44,14 @@ function NonDisRES(
 end
 
 """
-    profile(n::NonDisRES)
-    profile(n::NonDisRES, t)
+    profile(n::AbstractNonDisRES)
+    profile(n::AbstractNonDisRES, t)
 
-Returns the profile of a node `n` of type `NonDisRES` either as `TimeProfile` or in
+Returns the profile of a node `n` of type `AbstractNonDisRES` either as `TimeProfile` or in
 operational period `t`.
 """
-profile(n::NonDisRES) = n.profile
-profile(n::NonDisRES, t) = n.profile[t]
+profile(n::AbstractNonDisRES) = n.profile
+profile(n::AbstractNonDisRES, t) = n.profile[t]
 
 """ An abstract type for hydro storage nodes, with or without pumping. """
 abstract type HydroStorage{T} <: EMB.Storage{T} end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,10 +1,11 @@
 
 """
-    EMB.variables_node(m, 𝒩ⁿᵈʳ::Vector{NonDisRES}, 𝒯, modeltype::EnergyModel)
+    EMB.variables_node(m, 𝒩ⁿᵈʳ::Vector{<:AbstractNonDisRES}, 𝒯, modeltype::EnergyModel)
 
-Create the optimization variable `:curtailment` for every NonDisRES node. This method is called
-from `EnergyModelsBase.jl`."""
-function EMB.variables_node(m, 𝒩ⁿᵈʳ::Vector{NonDisRES}, 𝒯, modeltype::EnergyModel)
+Create the optimization variable `:curtailment` for every [`AbstractNonDisRES`](@ref) node.
+This method is called from `EnergyModelsBase.jl`.
+"""
+function EMB.variables_node(m, 𝒩ⁿᵈʳ::Vector{<:AbstractNonDisRES}, 𝒯, modeltype::EnergyModel)
     @variable(m, curtailment[𝒩ⁿᵈʳ, 𝒯] ≥ 0)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,20 +10,20 @@ const EMRP = EnergyModelsRenewableProducers
 
 @testset "RenewableProducers" begin
     include("utils.jl")
-    @testset "RP - Non-dispatchable renewable energy source" begin
+    @testset "RP | Non-dispatchable renewable energy source" begin
         include("test_nondisres.jl")
     end
 
-    @testset "RP - Hydropower" begin
+    @testset "RP | Hydropower" begin
         include("test_hydro.jl")
     end
 
-    @testset "RP - examples" begin
+    @testset "RP | examples" begin
         include("test_examples.jl")
     end
 
     redirect_stdio(stdout=devnull, stderr=devnull) do
-        @testset "RP - constructors" begin
+        @testset "RP | constructors" begin
             include("test_constructors.jl")
         end
     end

--- a/test/test_nondisres.jl
+++ b/test/test_nondisres.jl
@@ -1,102 +1,97 @@
+# Test that the fields of a NonDisRES are correctly checked
+# - check_node(n::NonDisRES, 𝒯, modeltype::EnergyModel)
+@testset "Checks" begin
 
-# Test set for the non dispatchable renewable energy source type
-@testset "Test NonDisRES" begin
+    # Set the global to true to suppress the error message
+    EMB.TEST_ENV = true
 
-    # Test that the fields of a NonDisRES are correctly checked
-    # - check_node(n::NonDisRES, 𝒯, modeltype::EnergyModel)
-    @testset "Checks" begin
+    # Test that a wrong capacity is caught by the checks.
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(-2),
+        OperationalProfile([0.9, 0.4, 0.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(10),
+        Dict(Power => 1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
 
-        # Set the global to true to suppress the error message
-        EMB.TEST_ENV = true
+    # Test that a wrong fixed OPEX is caught by the checks.
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(2),
+        OperationalProfile([0.9, 0.4, 0.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(-10),
+        Dict(Power => 1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
 
-        # Test that a wrong capacity is caught by the checks.
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(-2),
-            OperationalProfile([0.9, 0.4, 0.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(10),
-            Dict(Power => 1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
-        @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
+    # Test that a wrong output dictionary is caught by the checks.
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(2),
+        OperationalProfile([0.9, 0.4, 0.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(10),
+        Dict(Power => -1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
 
-        # Test that a wrong fixed OPEX is caught by the checks.
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(2),
-            OperationalProfile([0.9, 0.4, 0.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(-10),
-            Dict(Power => 1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
-        @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
+    # Test that a wrong profile is caught by the checks.
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(2),
+        OperationalProfile([-0.9, 0.4, 0.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(10),
+        Dict(Power => 1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(2),
+        OperationalProfile([0.9, 0.4, 1.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(10),
+        Dict(Power => 1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
 
-        # Test that a wrong output dictionary is caught by the checks.
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(2),
-            OperationalProfile([0.9, 0.4, 0.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(10),
-            Dict(Power => -1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
-        @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
+    # Set the global again to false
+    EMB.TEST_ENV = false
+end
 
-        # Test that a wrong profile is caught by the checks.
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(2),
-            OperationalProfile([-0.9, 0.4, 0.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(10),
-            Dict(Power => 1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
-        @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(2),
-            OperationalProfile([0.9, 0.4, 1.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(10),
-            Dict(Power => 1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
-        @test_throws AssertionError EMB.run_model(case, modeltype, OPTIMIZER)
+@testset ":profile and :curtailment" begin
+    # Creation of the initial problem with the NonDisRES node
+    wind = EMRP.NonDisRES(
+        "wind",
+        FixedProfile(25),
+        OperationalProfile([0.9, 0.4, 0.6, 0.8]),
+        FixedProfile(10),
+        FixedProfile(10),
+        Dict(Power => 1),
+    )
+    case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
 
-        # Set the global again to false
-        EMB.TEST_ENV = false
-    end
+    # Run the model
+    m = EMB.run_model(case, modeltype, OPTIMIZER)
 
-    @testset ":profile and :curtailment" begin
-        # Creation of the initial problem with the NonDisRES node
-        wind = EMRP.NonDisRES(
-            "wind",
-            FixedProfile(25),
-            OperationalProfile([0.9, 0.4, 0.6, 0.8]),
-            FixedProfile(10),
-            FixedProfile(10),
-            Dict(Power => 1),
-        )
-        case, modeltype = small_graph(source=wind, ops=SimpleTimes(4,1))
+    # Extraction of the time structure
+    𝒯 = case[:T]
 
-        # Run the model
-        m = EMB.run_model(case, modeltype, OPTIMIZER)
+    # Run of the general tests
+    general_tests(m)
 
-        # Extraction of the time structure
-        𝒯 = case[:T]
-
-        # Run of the general tests
-        general_tests(m)
-
-        # Test that cap_use is correctly with respect to the profile.
-        # - EMB.constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
-        @test sum(
-            value.(m[:cap_use][wind, t]) + value.(m[:curtailment][wind, t]) ≈
-            EMRP.profile(wind, t) * value.(m[:cap_inst][wind, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
-        ) == length(𝒯)
-    end
+    # Test that cap_use is correctly with respect to the profile.
+    # - EMB.constraints_capacity(m, n::NonDisRES, 𝒯::TimeStructure, modeltype::EnergyModel)
+    @test sum(
+        value.(m[:cap_use][wind, t]) + value.(m[:curtailment][wind, t]) ≈
+        EMRP.profile(wind, t) * value.(m[:cap_inst][wind, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
+    ) == length(𝒯)
 end


### PR DESCRIPTION
This PR introduces a new abstract supertype for `NonDisRES` called `AbstractNonDisRES` as outlined in #25.
The functions were directly adjusted.

This PR closes #25 and is a new registration.