### PR TITLE
Inclusion of battery storage

### DIFF
--- a/docs/src/library/internals/methods-EMB.md
+++ b/docs/src/library/internals/methods-EMB.md
@@ -22,6 +22,7 @@ EnergyModelsBase.constraints_flow_in
 EnergyModelsBase.constraints_flow_out
 EnergyModelsBase.constraints_level_aux
 EnergyModelsBase.constraints_opex_var
+EnergyModelsBase.constraints_opex_fixed
 ```
 
 ## [Check methods](@id lib-int-met_emb-check)

--- a/docs/src/library/internals/methods-EMRP.md
+++ b/docs/src/library/internals/methods-EMRP.md
@@ -12,6 +12,10 @@ Pages = ["methods-EMRP.md"]
 EnergyModelsRenewableProducers.build_hydro_reservoir_vol_constraints
 EnergyModelsRenewableProducers.build_pq_constaints
 EnergyModelsRenewableProducers.build_schedule_constraint
+EnergyModelsRenewableProducers.constraints_usage
+EnergyModelsRenewableProducers.constraints_usage_iterate
+EnergyModelsRenewableProducers.constraints_usage_sp
+EnergyModelsRenewableProducers.constraints_reserve
 ```
 
 ## [Identification functions](@id lib-int-met-ident)
@@ -23,4 +27,16 @@ EnergyModelsRenewableProducers.is_active
 EnergyModelsRenewableProducers.has_penalty
 EnergyModelsRenewableProducers.has_penalty_up
 EnergyModelsRenewableProducers.has_penalty_down
+EnergyModelsRenewableProducers.has_degradation
+```
+
+## [Utility methods](@id lib-int-met-util)
+
+```@docs
+EnergyModelsRenewableProducers.capacity_max
+EnergyModelsRenewableProducers.linear_reformulation
+EnergyModelsRenewableProducers.multiplication_variables
+EnergyModelsRenewableProducers.previous_usage
+EnergyModelsRenewableProducers.capacity_reduction
+EnergyModelsRenewableProducers.replace_disjunct
 ```

--- a/docs/src/library/internals/methods-fields.md
+++ b/docs/src/library/internals/methods-fields.md
@@ -48,7 +48,18 @@ EnergyModelsRenewableProducers.water_resource
 EnergyModelsRenewableProducers.electricity_resource
 ```
 
-## [`Constraint`](@id lib-int-met_field-constraint)
+## [Battery fields](@id lib-int-met_field-bat)
+
+```@docs
+EnergyModelsRenewableProducers.battery_life
+EnergyModelsRenewableProducers.cycles
+EnergyModelsRenewableProducers.degradation
+EnergyModelsRenewableProducers.stack_cost
+EnergyModelsRenewableProducers.reserve_up
+EnergyModelsRenewableProducers.reserve_down
+```
+
+## [Scheduling constraints](@id lib-int-met_field-scheduling)
 
 ```@docs
 EnergyModelsRenewableProducers.resource

--- a/docs/src/library/internals/types-EMRP.md
+++ b/docs/src/library/internals/types-EMRP.md
@@ -12,19 +12,10 @@ Pages = ["types-EMRP.md"]
 EnergyModelsRenewableProducers.HydroUnit
 ```
 
-## [Constraint types](@id lib-int-types-con)
+## [Parameter supertypes](@id lib-int-types-para)
 
 ```@docs
 EnergyModelsRenewableProducers.AbstractScheduleType
-EnergyModelsRenewableProducers.MinSchedule
-EnergyModelsRenewableProducers.MaxSchedule
-EnergyModelsRenewableProducers.EqualSchedule
-EnergyModelsRenewableProducers.ScheduleConstraint
-```
-
-## [Power-flow curves](@id lib-int-types-pq)
-
-```@docs
 EnergyModelsRenewableProducers.AbstractPqCurve
-EnergyModelsRenewableProducers.PqPoints
+EnergyModelsRenewableProducers.AbstractBatteryLife
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -13,11 +13,14 @@ EnergyModelsRenewableProducers
 ```@docs
 HydroStorage
 AbstractNonDisRES
+AbstractBattery
 ```
 
 ### [Concrete types](@id lib-pub-node-concrete)
 
 ```@docs
+Battery
+ReserveBattery
 NonDisRES
 HydroStor
 PumpedHydroStor
@@ -31,4 +34,31 @@ HydroGate
 
 ```@docs
 RegHydroStor
+```
+
+## [Additional types](@id lib-pub-add)
+
+### [Providing a battery lifetime](@id lib-pub-add-bat_life)
+
+The battery nodes can have either an infinity lifetime or a finite lifetime in which the capacity is reduced due to charging the battery.
+In this case, the lifetime is given by the number of cycles.
+
+```@docs
+InfLife
+CycleLife
+```
+
+### [Constraint types](@id lib-int-types-con)
+
+```@docs
+MinSchedule
+MaxSchedule
+EqualSchedule
+ScheduleConstraint
+```
+
+### [Power-flow curves](@id lib-int-types-pq)
+
+```@docs
+PqPoints
 ```

--- a/ext/EMIExt/utils.jl
+++ b/ext/EMIExt/utils.jl
@@ -14,7 +14,7 @@ function RMP.multiplication_variables(
         #   `prod` = `stor_level_current * bat_stack_replacement_b`
         cap_lower_bound = FixedProfile(0)
         cap_upper_bound = EMI.max_installed(EMI.investment_data(n, :level))
-        prod = EMH.linear_reformulation(
+        prod = EMRP.linear_reformulation(
             m,
             𝒯ᴵⁿᵛ,
             var_b,

--- a/ext/EMIExt/utils.jl
+++ b/ext/EMIExt/utils.jl
@@ -1,0 +1,41 @@
+function RMP.multiplication_variables(
+    m,
+    n::AbstractBattery,
+    𝒯ᴵⁿᵛ,
+    modeltype::AbstractInvestmentModel
+)
+    if EMI.has_investment(n, :level)
+        var_b = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], m[:bat_stack_replacement_b][n, t_inv])
+        var_cont = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], m[:stor_level_current][n, t_inv])
+
+        # Calculate linear reformulation of the multiplication of
+        # `stor_level_current * bat_stack_replacement_b`.
+        # This is achieved through the introduction of an auxiliary variable
+        #   `prod` = `stor_level_current * bat_stack_replacement_b`
+        cap_lower_bound = FixedProfile(0)
+        cap_upper_bound = EMI.max_installed(EMI.investment_data(n, :level))
+        prod = EMH.linear_reformulation(
+            m,
+            𝒯ᴵⁿᵛ,
+            var_b,
+            var_cont,
+            cap_lower_bound,
+            cap_upper_bound,
+        )
+    else
+        # Calculation of the multiplication with the installed capacity of the node
+        prod = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
+            capacity(level(n), t_inv) * [:bat_stack_replacement_b][n, t_inv]
+        )
+    end
+    return prod
+end
+
+function capacity_max(n::AbstractBattery, t_inv, modeltype::AbstractInvestmentModel)
+    if EMI.has_investment(n, :level)
+        max_installed = capacity(level(n), t_inv) * cycles(n)
+    else
+        max_installed = EMI.max_installed(EMI.investment_data(n, :level)) * cycles(n)
+    end
+    return max_installed
+end

--- a/src/EnergyModelsRenewableProducers.jl
+++ b/src/EnergyModelsRenewableProducers.jl
@@ -39,5 +39,6 @@ export HydroStorage, RegHydroStor, HydroStor, PumpedHydroStor
 export HydroReservoir, HydroGenerator, HydroPump, HydroGate
 export PqPoints
 export ScheduleConstraint, MinSchedule, MaxSchedule, EqualSchedule
+export AbstractBattery, ReserveBattery
 
 end # module

--- a/src/EnergyModelsRenewableProducers.jl
+++ b/src/EnergyModelsRenewableProducers.jl
@@ -29,16 +29,25 @@ const TS = TimeStruct
 include("datastructures.jl")
 include("model.jl")
 include("checks.jl")
+include("utils.jl")
 include("constraint_functions.jl")
 
 # Legacy constructors for node types
 include("legacy_constructor.jl")
 
+# Non-dispatchable renewable energy sources types
 export AbstractNonDisRES, NonDisRES
+
+# Simple hydro power types
 export HydroStorage, RegHydroStor, HydroStor, PumpedHydroStor
+
+# Detailed hydro power types
 export HydroReservoir, HydroGenerator, HydroPump, HydroGate
 export PqPoints
 export ScheduleConstraint, MinSchedule, MaxSchedule, EqualSchedule
-export AbstractBattery, ReserveBattery
+
+# Battery types
+export AbstractBattery, Battery, ReserveBattery
+export InfLife, CycleLife
 
 end # module

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -21,17 +21,49 @@ function EMB.constraints_capacity(m, n::AbstractNonDisRES, 𝒯::TimeStructure, 
 
     constraints_capacity_installed(m, n, 𝒯, modeltype)
 end
-"""
-    constraints_capacity(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
 
-Function for creating the constraint on the maximum capacity of an [`ReserveBattery`](@ref).
-It includes in addition to the standard constraints constraints on the reserve of the battery
 """
-function EMB.constraints_capacity(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+    constraints_capacity(m, n::AbstractBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+Function for creating the constraint on the maximum capacity of an [`AbstractBattery`](@ref).
+
+Its function flow is changed from the standard approach through calling the function
+[`capacity_reduction`](@ref) to identify the reduced storage capacity, depending on the
+chosen [`AbstractBatteryLife`](@ref) type.
+"""
+function EMB.constraints_capacity(m, n::AbstractBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+    # Identify the reduction in storage level capacity
+    stor_level_red = capacity_reduction(m, n, 𝒯, modeltype)
+
     # Introduce the required constraints based on the installed capacity
-    @constraint(m, [t ∈ 𝒯], m[:stor_level][n, t] ≤ m[:stor_level_inst][n, t])
+    @constraint(m, [t ∈ 𝒯],
+        m[:stor_level][n, t] ≤
+            m[:stor_level_inst][n, t] - stor_level_red[t]
+    )
     @constraint(m, [t ∈ 𝒯], m[:stor_charge_use][n, t] ≤ m[:stor_charge_inst][n, t])
     @constraint(m, [t ∈ 𝒯], m[:stor_discharge_use][n, t] ≤ m[:stor_discharge_inst][n, t])
+
+    # Call of the function for determining the installed capacity
+    constraints_capacity_installed(m, n, 𝒯, modeltype)
+end
+
+"""
+    constraints_reserve(m, n::AbstractBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+    constraints_reserve(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+
+Function for creating the additional constraints on the capacity utilization to account
+for providing reserve capacity to the system.
+
+!!! tip "Default approach"
+    No constraints are added.
+
+!!! note "`ReserveBattery`"
+    Several constraints are added to guarantee that the provided reserve can be delivered
+    through the values of the variables `:stor_charge_use`, `stor_discharge_use`,
+    and `stor_level`.
+"""
+constraints_reserve(m, n::AbstractBattery, 𝒯::TimeStructure, modeltype::EnergyModel) = nothing
+function constraints_reserve(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     # Add the reserve constraints
     @constraint(m, [t ∈ 𝒯],
@@ -50,8 +82,6 @@ function EMB.constraints_capacity(m, n::ReserveBattery, 𝒯::TimeStructure, mod
         m[:stor_level][n, t] - m[:bat_res_down][n, t]
             ≥ 0
     )
-    # Call of the function for determining the installed capacity
-    constraints_capacity_installed(m, n, 𝒯, modeltype)
 end
 
 """
@@ -166,6 +196,209 @@ function EMB.constraints_level_aux(m, n::AbstractBattery, 𝒯, 𝒫, modeltype:
             m[:stor_charge_use][n, t] * inputs(n, p_stor) -
             m[:stor_discharge_use][n, t] / outputs(n, p_stor)
     )
+end
+"""
+    constraints_usage(m, n::AbstractBattery, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
+
+Function for creating the usage constraints for an `AbstractBattery`. These constraints
+calculate the usage of the battery up to each time step for the lifetime calculations.
+"""
+function constraints_usage(m, n::AbstractBattery, 𝒯, modeltype::EnergyModel)
+    # Declaration of the required subsets
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    p_stor = storage_resource(n)
+
+    # Mass/energy balance constraints for stored energy carrier.
+    for (t_inv_prev, t_inv) ∈ withprev(𝒯ᴵⁿᵛ)
+        # Creation of the iterator and call of the iterator function -
+        # The representative period is initiated with the current investment period to allow
+        # dispatching on it.
+        prev_pers = PreviousPeriods(t_inv_prev, nothing, nothing);
+        cyclic_pers = CyclicPeriods(t_inv, t_inv)
+        ts = t_inv.operational
+
+        # Constraint for the total usage in a given strategic period
+        @constraint(m,
+            m[:bat_use_sp][n, t_inv] ==
+                sum(
+                    m[:stor_charge_use][n, t] * inputs(n, p_stor) * scale_op_sp(t_inv, t)
+                for t ∈ t_inv)
+        )
+
+        # Constraint for calculating the charging utilization before the current strategic
+        # period
+        constraints_usage_sp(m, n, prev_pers, t_inv, modeltype)
+
+        # Iterate through the time structure for calculation of the individual charging
+        # cycles
+        constraints_usage_iterate(m, n, prev_pers, cyclic_pers, t_inv, t_inv, ts, modeltype)
+    end
+end
+"""
+    constraints_usage_sp(
+        m,
+        n::AbstractBattery,
+        prev_pers::PreviousPeriods,
+        t_inv::TS.AbstractStrategicPeriod,
+        modeltype::EnergyModel,
+    )
+
+Function for creating the constraints on the previous usage of an [`AbstractBattery`](@ref)
+before the beginning of a strategic period.
+
+In the case of the first strategic period, it fixes the variable `bat_prev_use_sp` to 0.
+In all subsequent strategic periods, the previous usage is calculated.
+"""
+function constraints_usage_sp(
+    m,
+    n::AbstractBattery,
+    prev_pers::PreviousPeriods{Nothing, Nothing, Nothing},
+    t_inv::TS.AbstractStrategicPeriod,
+    modeltype::EnergyModel,
+)
+
+    JuMP.fix(m[:bat_prev_use_sp][n, t_inv], 0; force=true)
+end
+function constraints_usage_sp(
+    m,
+    n::AbstractBattery,
+    prev_pers::PreviousPeriods{<:TS.AbstractStrategicPeriod, Nothing, Nothing},
+    t_inv::TS.AbstractStrategicPeriod,
+    modeltype::EnergyModel,
+)
+    t_inv_prev = strat_per(prev_pers)
+    p_stor = storage_resource(n)
+
+    @constraint(m,
+        m[:bat_prev_use_sp][n, t_inv] ==
+            # Initial usage in previous sp
+            m[:bat_prev_use][n, first(t_inv_prev)] -
+            m[:stor_charge_use][n, first(t_inv_prev)] * inputs(n, p_stor) *
+            duration(first(t_inv_prev)) +
+            # Increase in previous representative period
+            m[:bat_use_sp][n, t_inv_prev] * duration_strat(t_inv_prev)
+    )
+end
+
+"""
+    constraints_usage_iterate(
+        m,
+        n::AbstractBattery,
+        prev_pers::PreviousPeriods,
+        cyclic_pers::CyclicPeriods,
+        t_inv::TS.AbstractStrategicPeriod,
+        per,
+        ts::RepresentativePeriods,
+        modeltype::EnergyModel,
+    )
+
+Iterate through the individual time structures of an [`AbstractBattery`](@ref) node.
+
+In the case of `RepresentativePeriods`, additional constraints are calculated for the usage
+of the electrolyzer in representative periods through introducing the variable
+`bat_usage_rp[𝒩ᴱᴸ, 𝒯ʳᵖ]`.
+ """
+function constraints_usage_iterate(
+    m,
+    n::AbstractBattery,
+    prev_pers::PreviousPeriods,
+    cyclic_pers::CyclicPeriods,
+    t_inv::TS.AbstractStrategicPeriod,
+    per,
+    _::RepresentativePeriods,
+    modeltype::EnergyModel,
+)
+    # Declaration of the required subsets
+    𝒯ʳᵖ = repr_periods(per)
+    last_rp = last(𝒯ʳᵖ)
+    p_stor = storage_resource(n)
+
+    # Constraint for the total usage in a given representative period
+    @constraint(m, [t_rp ∈ 𝒯ʳᵖ],
+        m[:bat_usage_rp][n, t_rp] ==
+            sum(
+                m[:stor_charge_use][n, t] * inputs(n, p_stor) * scale_op_sp(per, t)
+            for t ∈ t_rp)
+    )
+
+    # Iterate through the operational structure
+    for (t_rp_prev, t_rp) ∈ withprev(𝒯ʳᵖ)
+        prev_pers = PreviousPeriods(EMB.strat_per(prev_pers), t_rp_prev, EMB.op_per(prev_pers));
+        cyclic_pers = CyclicPeriods(last_rp, t_rp)
+        ts = t_rp.operational.operational
+        constraints_usage_iterate(m, n, prev_pers, cyclic_pers, t_inv, t_rp, ts, modeltype)
+    end
+end
+"""
+In the case of `OperationalScenarios`, we purely iterate through the individual time
+structures.
+"""
+function constraints_usage_iterate(
+    m,
+    n::AbstractBattery,
+    prev_pers::PreviousPeriods,
+    cyclic_pers::CyclicPeriods,
+    t_inv::TS.AbstractStrategicPeriod,
+    per,
+    _::OperationalScenarios,
+    modeltype::EnergyModel,
+)
+    # Declaration of the required subsets
+    𝒯ˢᶜ = opscenarios(per)
+
+    # Iterate through the operational structure
+    for t_scp ∈ 𝒯ˢᶜ
+        ts = t_scp.operational.operational
+        constraints_usage_iterate(m, n, prev_pers, cyclic_pers, t_inv, t_scp, ts, modeltype)
+    end
+end
+
+"""
+In the case of `SimpleTimes`, the iterator function is at its lowest level. In this
+situation,the previous usage is calculated using the function [`previous_usage`](@ref).
+The approach for calculating the constraints is depending on the types in the parameteric
+type [`EMB.PreviousPeriods`](@extref EnergyModelsBase.PreviousPeriods).
+"""
+function constraints_usage_iterate(
+    m,
+    n::AbstractBattery,
+    prev_pers::PreviousPeriods,
+    cyclic_pers::CyclicPeriods,
+    t_inv::TS.AbstractStrategicPeriod,
+    per,
+    _::SimpleTimes,
+    modeltype::EnergyModel,
+)
+    # Declaration of the required subsets
+    p_stor = storage_resource(n)
+
+    # Constraint for the total charging of the battery including the current time step.
+    # This ensures that the last repetition of the strategic period is appropriately
+    # constrained.
+    # The conditional statement activates this constraint only for the last representative
+    # period, if representative periods are present as stack replacement is only feasible
+    # once per strategic period
+    if last_per(cyclic_pers) == current_per(cyclic_pers) && !isnothing(cycles(n))
+        t = last(per)
+        @constraint(m,
+            cycles(n) * m[:stor_level_inst][n, t] ≥
+                m[:bat_prev_use][n, t] +
+                m[:bat_use_sp][n, t_inv] * duration_strat(t_inv)
+        )
+    end
+
+    # Iterate through the operational structure
+    for (t_prev, t) ∈ withprev(per)
+        prev_pers = PreviousPeriods(strat_per(prev_pers), rep_per(prev_pers), t_prev);
+
+        # Add the constraints for the previous usage
+        prev_use = previous_usage(m, n, t_inv, prev_pers, modeltype)
+
+        @constraint(m,
+            m[:bat_prev_use][n, t] ==
+                prev_use + m[:stor_charge_use][n, t] * inputs(n, p_stor) * duration(t)
+        )
+    end
 end
 
 #! format: on

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -78,7 +78,7 @@ except for water inflow from outside the model, although it requires a field `in
 - **`input::Dict{Resource, Real}`** are the input `Resource`s. In the case of a `HydroStor`,
   this field can be left out.
 - **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
-- **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
+- **`data::Vector{Data}`** additional data (*e.g.*, for investments). The field `data` is
   conditional through usage of a constructor.
 """
 struct HydroStor{T} <: HydroStorage{T}
@@ -189,11 +189,11 @@ account for the potential to store energy in the form of potential energy.
 - **`charge::EMB.UnionCapacity`** are the charging parameters of the `PumpedHydroStor` node.
   Depending on the chosen type, the charge parameters can include variable OPEX, fixed OPEX,
   and/or a capacity.
-- **`level::EMB.UnionCapacity`** are the level parameters of the `HydroStor` node.
+- **`level::EMB.UnionCapacity`** are the level parameters of the `PumpedHydroStor` node.
   Depending on the chosen type, the charge parameters can include variable OPEX and/or fixed OPEX.
-- **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `HydroStor` node.
-  Depending on the chosen type, the discharge parameters can include variable OPEX, fixed OPEX,
-  and/or a capacity.
+- **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `PumpedHydroStor`
+  node. Depending on the chosen type, the discharge parameters can include variable OPEX,
+  fixed OPEX, and/or a capacity.
 - **`level_init::TimeProfile`** is the initial stored energy in the dam.
 - **`level_inflow::TimeProfile`** is the inflow of power per operational period.
 - **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
@@ -201,7 +201,7 @@ account for the potential to store energy in the form of potential energy.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.
 - **`input::Dict{Resource, Real}`** are the input `Resource`s.
 - **`output::Dict{Resource, Real}`** can only contain one entry, the stored resource.
-- **`data::Vector{Data}`** additional data (e.g. for investments). The field `data` is
+- **`data::Vector{Data}`** additional data (*e.g.*, for investments). The field `data` is
   conditional through usage of a constructor.
 """
 struct PumpedHydroStor{T} <: HydroStorage{T}
@@ -872,3 +872,119 @@ function EMB.capacity(n::HydroUnit, t, p::Resource)
         "electricity resource of HydroUnit `n`.")
 end
 EMB.capacity(n::HydroGate, t, p::Resource) = EMB.capacity(n, t)
+
+
+"""
+    AbstractBattery{T} <: EMB.Storage{T}
+
+Abstract supertype for the different battery storage models.
+"""
+abstract type AbstractBattery{T} <: EMB.Storage{T} end
+
+"""
+    ReserveBattery{T} <: AbstractBattery{T}
+
+A battery storage, modelled as a `Storage` node. A battery storage nodes differs from a
+[`RefStorage`](@extref EnergyModelsBase.RefStorage) node through:
+
+1. incorporating a discharge capacity,
+2. including charge and discharge efficiencies, and
+3. allow for the introduction of both upwards and downwards reserves.
+
+!!! warning "Implementation details"
+    - The discharge and charge capacities are independent of each other.
+    - The values for the charge and discharge efficiencies must be smaller than 1.
+    - The upwards and downwards reserves are implemented as resources leaving the battery.
+      It is hence important to also provide a potential sink which determines the total
+      reserve required in the system.
+
+## Fields
+- **`id`** is the name/identifyer of the node.
+- **`charge::EMB.UnionCapacity`** are the charging parameters of the `BatteryStorage` node.
+  Depending on the chosen type, the charge parameters can include variable OPEX, fixed OPEX,
+  and/or a capacity.
+- **`level::EMB.UnionCapacity`** are the level parameters of the `BatteryStorage` node.
+  Depending on the chosen type, the charge parameters can include variable OPEX and/or
+  fixed OPEX.
+- **`discharge::EMB.UnionCapacity`** are the discharging parameters of the `BatteryStorage`
+  node. Depending on the chosen type, the discharge parameters can include variable OPEX,
+  fixed OPEX, and/or a capacity.
+- **`stor_res::ResourceCarrier`** is the stored `Resource`.
+- **`input::Dict{Resource, Real}`** are the input `Resource`s with corresponding efficiency
+  value.
+- **`output::Dict{Resource, Real}`** are the output `Resource`s with corresponding
+  efficiency value.
+- **`reserve_up::Vector{ResourceCarrier}`** are the `Resource`s used as reserve for
+  providing energy to the system.
+- **`reserve_down::Vector{ResourceCarrier}`** are the `Resource`s used as reserve for
+  removing energy from the system.
+- **`data::Vector{Data}`** additional data (*e.g.*, for investments). The field `data` is
+  conditional through usage of a constructor.
+"""
+struct ReserveBattery{T} <: AbstractBattery{T}
+    id
+    charge::EMB.UnionCapacity
+    level::EMB.UnionCapacity
+    discharge::EMB.UnionCapacity
+
+    stor_res::ResourceCarrier
+    input::Dict{<:Resource, <:Real}
+    output::Dict{<:Resource, <:Real}
+    reserve_up::Vector{<:ResourceCarrier}
+    reserve_down::Vector{<:ResourceCarrier}
+    data::Vector{<:Data}
+end
+function ReserveBattery{T}(
+    id,
+    charge::EMB.UnionCapacity,
+    level::EMB.UnionCapacity,
+    discharge::EMB.UnionCapacity,
+
+    stor_res::Resource,
+    input::Dict{<:Resource, <:Real},
+    output::Dict{<:Resource, <:Real},
+    reserve_up::Vector{<:ResourceCarrier},
+    reserve_down::Vector{<:ResourceCarrier},
+) where {T}
+    return ReserveBattery{T}(
+        id,
+        charge,
+        level,
+        discharge,
+        stor_res,
+        input,
+        output,
+        reserve_up,
+        reserve_down,
+        Data[],
+    )
+end
+
+"""
+    EMB.outputs(n::ReserveBattery)
+    EMB.outputs(n::ReserveBattery, p::Resource)
+
+When the node is an [`ReserveBattery`](@ref), it returns both the output and reserve
+resources.
+
+If the resource `p` is specified, it returns the value if the resource is in the output
+dictionary. Otherwise, it returns a value of 0.
+"""
+EMB.outputs(n::ReserveBattery) =
+    unique(vcat(collect(keys(n.output)), n.reserve_up, n.reserve_down))
+EMB.outputs(n::ReserveBattery, p::Resource) =
+    haskey(n.output, p) ? n.output[p] : 0
+
+"""
+    reserve_up(n::ReserveBattery)
+
+Returns the instances used as reserve resources for adding capacity to the energy system.
+"""
+reserve_up(n::ReserveBattery) = n.reserve_up
+
+"""
+    reserve_down(n::ReserveBattery)
+
+Returns the instances used as reserve resources for removing capacity from the energy system.
+"""
+reserve_down(n::ReserveBattery) = n.reserve_down

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -901,10 +901,13 @@ number of cycles.
 - **`cycles::Int`** is the number of cycles that the battery can tolerate.
 - **`degradation::Float64`** is the allowed capacity reduction at the end of life of the
   battery.
+- **`stack_cost::Float64`** is the relative cost for replacing a battery stack once it
+  reached its maximum number of cycles.
 """
 struct CycleLife <: AbstractBatteryLife
     cycles::Int
     degradation::Float64
+    stack_cost::Float64
 end
 
 """
@@ -1103,6 +1106,14 @@ Returns the [`AbstractBatteryLife`](@ref) type of AbstractBattery `n`.
 battery_life(n::AbstractBattery) = n.battery_life
 
 """
+    has_degradation(n::AbstractBattery)
+
+Returns logic whether the AbstractBattery includes degradation of the battery and
+replacement options for the battery.
+"""
+has_degradation(n::AbstractBattery) = isa(battery_life(n), CycleLife)
+
+"""
     cycles(n::AbstractBattery)
     cycles(life::AbstractBatteryLife)
     cycles(life::CycleLife)
@@ -1126,3 +1137,16 @@ it will return `nothing`.
 degradation(n::AbstractBattery) = degradation(battery_life(n))
 degradation(life::AbstractBatteryLife) = nothing
 degradation(life::CycleLife) = life.degradation
+
+"""
+    stack_cost(n::AbstractBattery)
+    stack_cost(life::AbstractBatteryLife)
+    stack_cost(life::CycleLife)
+
+Returns the relative stack cost of the battery storage capacity for replacing the existing
+battery capacity. If the [`battery_life`](@ref) is an [`AbstractBatteryLife`](@ref),
+it will return `nothing`.
+"""
+stack_cost(n::AbstractBattery) = stack_cost(battery_life(n))
+stack_cost(life::AbstractBatteryLife) = nothing
+stack_cost(life::CycleLife) = life.stack_cost

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -992,7 +992,7 @@ end
     ReserveBattery{T} <: AbstractBattery{T}
 
 A reserve battery storage, modelled as a `Storage` node. A battery storage nodes differs
-from a [`Battery`](ref) node through allowing for the introduction of both upwards and
+from a [`Battery`](@ref) node through allowing for the introduction of both upwards and
 downwards reserves.
 
 !!! warning "Implementation details"

--- a/src/model.jl
+++ b/src/model.jl
@@ -181,10 +181,15 @@ The following reserve variables are declared:
 - `bat_usage_rp[n, t_rp]` is the accummulated charge effect of an `AbstractBattery` in
   representative period `t_rp`. It is only declared if the `TimeStructure` includes
   `RepresentativePeriods`.
+- `bat_stack_replacement_b[n, t_inv]` is a binary variable for identification of battery
+  stack replacement. Stack replacement occurs before the first operational period of a
+  strategic period. It is only declared for batterys which utilize an
+  [`AbstractBatteryLife`](@ref) that includes degradation.
 """
 function EMB.variables_node(m, 𝒩::Vector{<:AbstractBattery}, 𝒯, modeltype::EnergyModel)
     # Declaration of the required subsets
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    𝒩ᶜˡ = filter(has_degradation, 𝒩)
 
     # Variables for degredation
     @variable(m, bat_prev_use[𝒩, 𝒯] ≥ 0)
@@ -194,6 +199,7 @@ function EMB.variables_node(m, 𝒩::Vector{<:AbstractBattery}, 𝒯, modeltype:
         𝒯ʳᵖ = repr_periods(𝒯)
         @variable(m, bat_usage_rp[𝒩, 𝒯ʳᵖ])
     end
+    @variable(m, bat_stack_replacement_b[𝒩ᶜˡ, 𝒯ᴵⁿᵛ], Bin)
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -166,3 +166,18 @@ function EMB.variables_node(m, 𝒩::Vector{<:HydroUnit}, 𝒯, modeltype::Energ
         any([has_penalty_down(c, t, p) for c in constraint_data(n)])
     ] ≥ 0)
 end
+
+"""
+    EMB.variables_node(m, 𝒩::Vector{<:ReserveBattery}, 𝒯, modeltype::EnergyModel)
+
+Declaration of reserve variables for [`ReserveBattery`](@ref) nodes.
+The following reserve variables are declared:
+
+- `bat_res_up[n, t]` is the upwards reserve of battery storage `n` in operational period `t`.
+- `bat_res_down[n, t]` is the upwards reserve of battery of storage `n` in operational
+  period `t`.
+"""
+function EMB.variables_node(m, 𝒩::Vector{<:ReserveBattery}, 𝒯, modeltype::EnergyModel)
+    @variable(m, bat_res_up[𝒩, 𝒯] ≥ 0)
+    @variable(m, bat_res_down[𝒩, 𝒯] ≥ 0)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,7 +50,7 @@ end
     )
 
 Returns the previous usage of an `AbstractBattery` node depending on the type of
-[`PreviousPeriods`](@ref).
+[`PreviousPeriods`](@extref EnergyModelsBase.PreviousPeriods).
 
 The basic functionality is used in the case when the previous operational period is a
 `TimePeriod`, in which case it just returns the previous operational period.
@@ -103,6 +103,28 @@ function previous_usage(
         m[:bat_usage_rp][n, t_rp_prev]
     )
 end
+"""
+    linear_reformulation(
+        m,
+        𝒯,
+        var_binary,
+        var_continuous,
+        lb::TimeProfile,
+        ub::TimeProfile,
+    )
+
+Linear reformulation of the element-wise multiplication of the binary variable `var_binary[𝒯]`
+and the continuous variable `var_continuous[𝒯] ∈ [ub, lb]`.
+
+It returns the product `var_aux[𝒯]` with
+
+``var\\_aux[t] = var\\_binary[t] \\times var\\_continuous[t]``.
+
+!!! note
+    The bounds `lb` and `ub` must have the ability to access their fields using the iterator
+    of `𝒯`, that is if `𝒯` corresponds to the strategic periods, it is not possible to
+    provide an `OperationalProfile` or `RepresentativeProfile`.
+"""
 function linear_reformulation(
     m,
     𝒯,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,105 @@
+"""
+    capacity_reduction(
+        m,
+        n::AbstractBattery,
+        bat_life::AbstractBatteryLife,
+        𝒯::TimeStructure,
+        modeltype::EnergyModel,
+    )
+
+Returns the reduction in the storage capacity of an [`AbstractBattery`](@ref) depending once
+on the chosen [`AbstractBatteryLife`](@ref).
+
+!!! tip "Default approach"
+    Returns a value of 0 indicating no reduction in storage capacity.
+
+!!! note "`CycleLife`"
+    Returns the reduction in storage level capacity as linear multiplier of the charge usage
+    of the Battery through the fields `cycles` and `degradation` of the [`CycleLife`](@ref).
+"""
+capacity_reduction(m, n::AbstractBattery, 𝒯::TimeStructure, modeltype::EnergyModel) =
+    capacity_reduction(m, n, battery_life(n), 𝒯, modeltype)
+function capacity_reduction(
+    m,
+    n::AbstractBattery,
+    bat_life::AbstractBatteryLife,
+    𝒯::TimeStructure,
+    modeltype::EnergyModel,
+)
+    return @expression(m, [t ∈ 𝒯], 0)
+end
+function capacity_reduction(
+    m,
+    n::AbstractBattery,
+    bat_life::CycleLife,
+    𝒯::TimeStructure,
+    modeltype::EnergyModel,
+)
+    return @expression(m, [t ∈ 𝒯],
+        degradation(bat_life) * m[:bat_prev_use][n, t] / cycles(bat_life)
+    )
+end
+
+"""
+    previous_usage(
+        m,
+        n::AbstractBattery,
+        t_inv::TimeStruct.AbstractStrategicPeriod,
+        prev_pers::PreviousPeriods,
+        modeltype::EnergyModel,
+    )
+
+Returns the previous usage of an `AbstractBattery` node depending on the type of
+[`PreviousPeriods`](@ref).
+
+The basic functionality is used in the case when the previous operational period is a
+`TimePeriod`, in which case it just returns the previous operational period.
+"""
+function previous_usage(
+    m,
+    n::AbstractBattery,
+    t_inv::TimeStruct.AbstractStrategicPeriod,
+    prev_pers::PreviousPeriods,
+    modeltype::EnergyModel,
+)
+    t_prev = op_per(prev_pers)
+    return @expression(m, m[:bat_prev_use][n, t_prev])
+end
+"""
+When the previous operational and representative periods are `Nothing`, the variable
+`bat_prev_use_sp` is used for the initial usage in a strategic period
+"""
+function previous_usage(
+    m,
+    n::AbstractBattery,
+    t_inv::TimeStruct.AbstractStrategicPeriod,
+    prev_pers::PreviousPeriods{<:EMB.NothingPeriod, Nothing, Nothing},
+    modeltype::EnergyModel,
+)
+    # Return the previous usage through the variable `bat_prev_use_sp`
+    return @expression(m, m[:bat_prev_use_sp][n, t_inv])
+end
+"""
+When the previous operational period is `Nothing` and the previous representative period an
+`AbstractRepresentativePeriod` then the time structure *does* include `RepresentativePeriods`.
+
+The constraint then sums up the values from the previous representative period.
+"""
+function previous_usage(
+    m,
+    n::AbstractBattery,
+    t_inv::TimeStruct.AbstractStrategicPeriod,
+    prev_pers::PreviousPeriods{<:EMB.NothingPeriod, <:TS.AbstractRepresentativePeriod, Nothing},
+    modeltype::EnergyModel,
+)
+    t_rp_prev = rep_per(prev_pers)
+    p_stor = storage_resource(n)
+    return @expression(m,
+        # Initial usage in previous rp
+        m[:bat_prev_use][n, first(t_rp_prev)] -
+        m[:stor_charge_use][n, first(t_rp_prev)] * inputs(n, p_stor) *
+        duration(first(t_rp_prev)) +
+        # Increase in previous representative period
+        m[:bat_usage_rp][n, t_rp_prev]
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,29 +12,29 @@ const EMRP = EnergyModelsRenewableProducers
 @testset "RenewableProducers" begin
     include("utils.jl")
 
-    @testset "RP | Non-dispatchable renewable energy source" begin
-        include("test_nondisres.jl")
-    end
+    # @testset "RP | Non-dispatchable renewable energy source" begin
+    #     include("test_nondisres.jl")
+    # end
 
-    @testset "RP | Hydropower" begin
-        include("test_hydro.jl")
-    end
+    # @testset "RP | Hydropower" begin
+    #     include("test_hydro.jl")
+    # end
 
-    @testset "RP | Detailed hydropower" begin
-        include("test_detailed_hydro.jl")
-    end
+    # @testset "RP | Detailed hydropower" begin
+    #     include("test_detailed_hydro.jl")
+    # end
 
     @testset "RP | Battery storage" begin
         include("test_battery.jl")
     end
 
-    @testset "RP | examples" begin
-        include("test_examples.jl")
-    end
+    # @testset "RP | examples" begin
+    #     include("test_examples.jl")
+    # end
 
-    redirect_stdio(stdout=devnull, stderr=devnull) do
-        @testset "RP | constructors" begin
-            include("test_constructors.jl")
-        end
-    end
+    # redirect_stdio(stdout=devnull, stderr=devnull) do
+    #     @testset "RP | constructors" begin
+    #         include("test_constructors.jl")
+    #     end
+    # end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ const EMRP = EnergyModelsRenewableProducers
 
 @testset "RenewableProducers" begin
     include("utils.jl")
+
     @testset "RP | Non-dispatchable renewable energy source" begin
         include("test_nondisres.jl")
     end
@@ -21,6 +22,10 @@ const EMRP = EnergyModelsRenewableProducers
 
     @testset "RP | Detailed hydropower" begin
         include("test_detailed_hydro.jl")
+    end
+
+    @testset "RP | Battery storage" begin
+        include("test_battery.jl")
     end
 
     @testset "RP | examples" begin

--- a/test/test_battery.jl
+++ b/test/test_battery.jl
@@ -1,43 +1,275 @@
 function general_battery_tests(m, case)
     # Extract the data
     𝒯 = case[:T]
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     𝒩 = case[:nodes]
     stor = 𝒩[2]
 
-    # Test that the level balance is correct for standard periods (6 times)
-    @test sum(
-        sum(
-            value.(m[:stor_level][stor, t]) ≈
-            value.(m[:stor_level][stor, t_prev]) +
-            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
-        ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-    ) ≈ length(𝒯) - 2 atol = TEST_ATOL
-
-    # Test that the level balance is correct in the first period (2 times)
-    @test sum(
-        sum(
-            value.(m[:stor_level][stor, t]) ≈
-            value.(m[:stor_level][stor, last(t_inv)]) +
-            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
-            (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev)
-        ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
-    ) ≈ 2 atol = TEST_ATOL
+    # Test that the level balance is correct for standard periods
+    @test all(
+        isapprox(
+            value.(m[:stor_level][stor, t]),
+                value.(m[:stor_level][stor, t_prev]) +
+                value.(m[:stor_level_Δ_op][stor, t]) * duration(t),
+        atol = TEST_ATOL)
+    for (t_prev, t) ∈ withprev(𝒯) if !isnothing(t_prev))
 
     # Test that the changes in the storage level is correctly calculated
     @test all(
-        value.(m[:stor_level_Δ_op][stor, t]) ≈
-            value.(m[:stor_charge_use][stor, t])*0.9 -
-            value.(m[:stor_discharge_use][stor, t])/0.9
+        isapprox(
+        value.(m[:stor_level_Δ_op][stor, t]),
+            value.(m[:stor_charge_use][stor, t]) * 0.9 -
+            value.(m[:stor_discharge_use][stor, t]) / 0.9,
+            atol = TEST_ATOL)
     for t ∈ 𝒯)
 
-    # Test that both the outlet flow is correctly calculated.
+    # Test that the outlet flow is correctly calculated.
     # The inlet flow is based on the standard approach
     @test all(
         value.(m[:flow_out][stor, t, Power]) ≈
             value.(m[:stor_discharge_use][stor, t])
     for t ∈ 𝒯)
+end
+
+@testset "Battery" begin
+
+    function small_graph(
+        supply_price,
+        el_demand;
+        ops = SimpleTimes(10, [6, 3, 6, 3, 6, 6, 3, 6, 3, 6]),
+        bat_life = InfLife(),
+    )
+
+        products = [Power, CO2]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "power_source",
+            FixedProfile(20),
+            supply_price,
+            FixedProfile(1),
+            Dict(Power => 1),
+        )
+        battery = Battery{CyclicRepresentative}(
+            "battery",
+            StorCap(FixedProfile(20)),
+            StorCap(FixedProfile(50)),
+            StorCap(FixedProfile(20)),
+            Power,
+            Dict(Power => 0.9),
+            Dict(Power => 0.9),
+            bat_life,
+        )
+        sink = RefSink(
+            "power_demand",
+            el_demand,
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e3)),
+            Dict(Power => 1),
+        )
+
+        nodes = [source, battery, sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[3])
+            Direct("source-bat", nodes[1], nodes[2])
+            Direct("bat-sink", nodes[2], nodes[3])
+        ]
+
+        # Creation of the time structure and the used global data
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, ops; op_per_strat)
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        # Creation and solving of the model
+        m = create_model(case, modeltype)
+        set_optimizer(m, OPTIMIZER)
+        optimize!(m)
+
+        return m, case, modeltype
+    end
+
+    function battery_prev_usage_tests(m, case)
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        stor = case[:nodes][2]
+        # Test that the charge usage is correctly calculated and accounting for the length of
+        # both operational and strategic periods in the first operational period of a
+        # strategic period
+        # - constraints_usage(m, n::AbstractBattery, 𝒯, modeltype::EnergyModel)
+        # - previous_usage
+        t_sp1 = first(𝒯ᴵⁿᵛ[1])
+        @test value.(m[:bat_prev_use][stor, t_sp1]) ≈
+            value.(m[:stor_charge_use])[stor, t_sp1] * 0.9 * duration(t_sp1)
+        t_sp2 = first(𝒯ᴵⁿᵛ[2])
+        @test value.(m[:bat_prev_use][stor, t_sp2]) ≈
+            value.(m[:bat_prev_use][stor, t_sp1]) -
+            value.(m[:stor_charge_use])[stor, t_sp1] * 0.9 * duration(t_sp1) +
+            2 * value.(m[:bat_use_sp][stor, first(𝒯ᴵⁿᵛ)]) +
+            value.(m[:stor_charge_use])[stor, t_sp2] * 0.9 * duration(t_sp2)
+
+        # Test that the previous usage is correctly calculated in each individual operational
+        # period that does have a previous period
+        @test all(
+            value.(m[:bat_prev_use][stor, t]) ≈
+                value.(m[:bat_prev_use][stor, t_prev]) +
+                value.(m[:stor_charge_use])[stor, t] * 0.9 * duration(t)
+        for (t_prev, t) ∈ withprev(𝒯) if !isnothing(t_prev))
+    end
+
+    function battery_degradation_tests(m, case)
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩 = case[:nodes]
+        stor = 𝒩[2]
+        sink = 𝒩[3]
+        # Test that the capacity limit is correctly enforced in the complete horizon
+        # - constraints_usage_iterate:
+        #   - Division by 50 to account for the installed storage capacity of the battery
+        #   - Multiplication with 2 to account for the duration of the strategic period
+        #   - The value of 900 correspondsd to the cycle numbers
+        @test sum(value.(m[:bat_use_sp])) / 50 * 2 ≤ 900
+
+        # Test that the capacity limit is correctly enforced in the individual operational
+        # periods
+        # - capacity_reduction and constraints_capacity:
+        #   - The value of 50 corresponds to the installed storage capacity of the battery
+        #   - The value of 0.8 corresponds to 1-the final degradation percentage
+        #   - The value of 900 correspondsd to the cycle numbers
+        @test all(
+            value.(m[:stor_level][stor, t]) ≤
+                50 - 0.2 * value.(m[:bat_prev_use][stor, t]) / 900
+        for t ∈ 𝒯)
+
+        # Test that the total deficit is smaller in the first strategic period due to the
+        # larger storage size
+        @test sum(value.(m[:sink_deficit][sink, t]) * duration(t) for t ∈ 𝒯ᴵⁿᵛ[1]) <
+            sum(value.(m[:sink_deficit][sink, t]) * duration(t) for t ∈ 𝒯ᴵⁿᵛ[2])
+    end
+
+    # Modelling of two days with typical demand and price profiles
+    el_demand = OperationalProfile([16; 28; 20; 25; 18; 15; 25; 20; 28; 18])
+    supply_price = OperationalProfile([30; 80; 60; 80; 40; 30; 80; 60; 80; 40])
+
+    @testset "SimpleTimes - No cycle limit" begin
+        m, case, modeltype = small_graph(supply_price, el_demand)
+
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        stor = case[:nodes][2]
+
+        # Run the standard tests
+        general_battery_tests(m, case)
+        battery_prev_usage_tests(m, case)
+
+        # Test that the level balance is correct in the first operational periods of each
+        # strategic period
+        @test all(
+                value.(m[:stor_level][stor, first(t_inv)]) ≈
+                    value.(m[:stor_level][stor, last(t_inv)]) +
+                    value.(m[:stor_level_Δ_op][stor, first(t_inv)]) * duration(first(t_inv))
+            for t_inv ∈ 𝒯ᴵⁿᵛ
+        )
+    end
+    @testset "SimpleTimes - Cycle limit" begin
+        bat_life = CycleLife(900, 0.2)
+        m, case, modeltype = small_graph(supply_price, el_demand; bat_life)
+
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩 = case[:nodes]
+        stor = 𝒩[2]
+        sink = 𝒩[3]
+
+        # Run the standard tests
+        general_battery_tests(m, case)
+        battery_prev_usage_tests(m, case)
+        battery_degradation_tests(m, case)
+    end
+
+    # Modelling of two days as one representative period each with typical demand and price
+    # profiles
+    ops = RepresentativePeriods(
+        2,          # Number of representative periods
+        8760,       # Total duration in a strategic period
+        [0.5, 0.5], # Probability of each representative period
+        [
+            SimpleTimes(5, [6, 3, 6, 3, 6]),
+            SimpleTimes(5, [6, 3, 6, 3, 6]),
+        ]
+    );
+    el_demand = RepresentativeProfile([
+        OperationalProfile([16; 29; 20; 25; 17]);
+        OperationalProfile([15; 26; 20; 28; 18]);
+    ])
+    supply_price = OperationalProfile([30; 80; 60; 80; 40])
+
+    @testset "RepresentativePeriods - No cycle limit" begin
+        m, case, modeltype = small_graph(supply_price, el_demand; ops)
+
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩 = case[:nodes]
+        stor = 𝒩[2]
+
+        # Run the standard tests
+        general_battery_tests(m, case)
+        battery_prev_usage_tests(m, case)
+
+        # Test that the previous usage is correctly calculated in the first operational
+        # period of representative periods that are not the first
+        @test all(
+            value.(m[:bat_prev_use][stor, first(t_rp)]) ≈
+                value.(m[:bat_prev_use][stor, first(t_rp_prev)]) -
+                value.(m[:stor_charge_use][stor, first(t_rp_prev)]) *
+                0.9 * duration(first(t_rp_prev)) +
+                value.(m[:bat_usage_rp][stor, t_rp_prev]) +
+                value.(m[:stor_charge_use][stor, first(t_rp)]) * 0.9 * duration(first(t_rp))
+            for t_inv ∈ 𝒯ᴵⁿᵛ for (t_rp_prev, t_rp) ∈ withprev(repr_periods(t_inv))
+        if !isnothing(t_rp_prev))
+    end
+
+    @testset "RepresentativePeriods - Cycle limit" begin
+        bat_life = CycleLife(900, 0.2)
+        m, case, modeltype = small_graph(supply_price, el_demand; ops, bat_life)
+
+        # Extract the data
+        𝒯 = case[:T]
+        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+        𝒩 = case[:nodes]
+        stor = 𝒩[2]
+        sink = 𝒩[3]
+
+        # Run the standard tests
+        general_battery_tests(m, case)
+        battery_prev_usage_tests(m, case)
+
+        # Test that the capacity limit is correctly enforced in the complete horizon
+        # - constraints_usage_iterate:
+        #   - Division by 50 to account for the installed storage capacity of the battery
+        #   - Multiplication with 2 to account for the duration of the strategic period
+        #   - The value of 900 correspondsd to the cycle numbers
+        @test sum(value.(m[:bat_use_sp])) / 50 * 2 ≤ 900
+
+        # Test that the capacity limit is correctly enforced in the individual operational
+        # periods
+        # - capacity_reduction and constraints_capacity:
+        #   - The value of 50 corresponds to the installed storage capacity of the battery
+        #   - The value of 0.8 corresponds to 1-the final degradation percentage
+        #   - The value of 900 correspondsd to the cycle numbers
+        @test all(
+            value.(m[:stor_level][stor, t]) ≤
+                50 - 0.2 * value.(m[:bat_prev_use][stor, t]) / 900
+        for t ∈ 𝒯)
+    end
 end
 
 @testset "ReserveBattery" begin
@@ -49,6 +281,7 @@ end
         el_demand;
         res_down_demand = FixedProfile(10),
         res_up_demand = FixedProfile(10),
+        ops = SimpleTimes(10, [6, 3, 6, 3, 6, 6, 3, 6, 3, 6]),
     )
 
         products = [Power, reserve_down, reserve_up, CO2]
@@ -68,6 +301,7 @@ end
             Power,
             Dict(Power => 0.9),
             Dict(Power => 0.9),
+            InfLife(),
             [reserve_up],
             [reserve_down],
         )
@@ -100,7 +334,8 @@ end
         ]
 
         # Creation of the time structure and the used global data
-        T = TwoLevel(2, 1, SimpleTimes(10, [6, 3, 6, 3, 6, 6, 3, 6, 3, 6]))
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, ops; op_per_strat)
         modeltype = OperationalModel(
             Dict(CO2 => FixedProfile(10)),
             Dict(CO2 => FixedProfile(0)),
@@ -130,7 +365,6 @@ end
     stor = 𝒩[2]
 
     # Run the standard tests
-    general_tests(m)
     general_battery_tests(m, case)
 
     # Test that the reserve equals the flow out

--- a/test/test_battery.jl
+++ b/test/test_battery.jl
@@ -1,0 +1,167 @@
+function general_battery_tests(m, case)
+    # Extract the data
+    𝒯 = case[:T]
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    𝒩 = case[:nodes]
+    stor = 𝒩[2]
+
+    # Test that the level balance is correct for standard periods (6 times)
+    @test sum(
+        sum(
+            value.(m[:stor_level][stor, t]) ≈
+            value.(m[:stor_level][stor, t_prev]) +
+            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
+            (t_prev, t) ∈ withprev(t_inv) if !isnothing(t_prev)
+        ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+    ) ≈ length(𝒯) - 2 atol = TEST_ATOL
+
+    # Test that the level balance is correct in the first period (2 times)
+    @test sum(
+        sum(
+            value.(m[:stor_level][stor, t]) ≈
+            value.(m[:stor_level][stor, last(t_inv)]) +
+            value.(m[:stor_level_Δ_op][stor, t]) * duration(t) for
+            (t_prev, t) ∈ withprev(t_inv) if isnothing(t_prev)
+        ) for t_inv ∈ 𝒯ᴵⁿᵛ, atol ∈ TEST_ATOL
+    ) ≈ 2 atol = TEST_ATOL
+
+    # Test that the changes in the storage level is correctly calculated
+    @test all(
+        value.(m[:stor_level_Δ_op][stor, t]) ≈
+            value.(m[:stor_charge_use][stor, t])*0.9 -
+            value.(m[:stor_discharge_use][stor, t])/0.9
+    for t ∈ 𝒯)
+
+    # Test that both the outlet flow is correctly calculated.
+    # The inlet flow is based on the standard approach
+    @test all(
+        value.(m[:flow_out][stor, t, Power]) ≈
+            value.(m[:stor_discharge_use][stor, t])
+    for t ∈ 𝒯)
+end
+
+@testset "ReserveBattery" begin
+    reserve_down = ResourceCarrier("Reserve Down", 0.0)
+    reserve_up = ResourceCarrier("Reserve Up", 0.0)
+
+    function small_graph(
+        supply_price,
+        el_demand;
+        res_down_demand = FixedProfile(10),
+        res_up_demand = FixedProfile(10),
+    )
+
+        products = [Power, reserve_down, reserve_up, CO2]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "power_source",
+            FixedProfile(20),
+            supply_price,
+            FixedProfile(1),
+            Dict(Power => 1),
+        )
+        battery = ReserveBattery{CyclicStrategic}(
+            "battery",
+            StorCap(FixedProfile(20)),
+            StorCap(FixedProfile(50)),
+            StorCap(FixedProfile(20)),
+            Power,
+            Dict(Power => 0.9),
+            Dict(Power => 0.9),
+            [reserve_up],
+            [reserve_down],
+        )
+        sink = RefSink(
+            "power_demand",
+            el_demand,
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e3)),
+            Dict(Power => 1),
+        )
+        reserve_down_sink = RefSink(
+            "reserve_down",
+            res_down_demand,
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(100)),
+            Dict(reserve_down => 1),
+        )
+        reserve_up_sink = RefSink(
+            "reserve_up",
+            res_up_demand,
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(50)),
+            Dict(reserve_up => 1),
+        )
+
+        nodes = [source, battery, sink, reserve_down_sink, reserve_up_sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[3])
+            Direct("source-bat", nodes[1], nodes[2])
+            Direct("bat-sink", nodes[2], nodes[3])
+            Direct("bat-reserve_down_sink", nodes[2], nodes[4])
+            Direct("bat-reserve_up_sink", nodes[2], nodes[5])
+        ]
+
+        # Creation of the time structure and the used global data
+        T = TwoLevel(2, 1, SimpleTimes(10, [6, 3, 6, 3, 6, 6, 3, 6, 3, 6]))
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        # Creation and solving of the model
+        m = create_model(case, modeltype)
+        set_optimizer(m, OPTIMIZER)
+        optimize!(m)
+
+        return m, case, modeltype
+    end
+
+    # Modelling of two days with typical demand and price profiles
+    el_demand = OperationalProfile([16; 28; 20; 25; 18; 15; 25; 20; 28; 18])
+    supply_price = OperationalProfile([30; 80; 60; 80; 40; 30; 80; 60; 80; 40])
+    m, case, modeltype = small_graph(supply_price, el_demand)
+
+    # Extract the data
+    𝒯 = case[:T]
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    𝒩 = case[:nodes]
+    stor = 𝒩[2]
+
+    # Run the standard tests
+    general_tests(m)
+    general_battery_tests(m, case)
+
+    # Test that the reserve equals the flow out
+    # - EMB.constraints_flow_out(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+    @test all(
+        value.(m[:flow_out][stor, t, reserve_down]) ≈
+            value.(m[:bat_res_down][stor, t])
+    for t ∈ 𝒯)
+    @test all(
+        value.(m[:flow_out][stor, t, reserve_up]) ≈
+            value.(m[:bat_res_up][stor, t])
+    for t ∈ 𝒯)
+
+    # Test that the reserve is correctly bounded from above through both the charge/discharge
+    # capacity and the level capacity
+    # - EMB.constraints_capacity(m, n::ReserveBattery, 𝒯::TimeStructure, modeltype::EnergyModel)
+    @test all(
+        value.(m[:bat_res_down][stor, t]) ≤ value.(m[:stor_level][stor, t]) + TEST_ATOL
+    for t ∈ 𝒯)
+    @test all(
+        value.(m[:bat_res_down][stor, t]) ≤
+            value.(m[:stor_discharge_use][stor, t]) - value.(m[:stor_charge_use][stor, t]) +
+            capacity(charge(stor), t) + TEST_ATOL
+    for t ∈ 𝒯)
+    @test all(
+        value.(m[:bat_res_up][stor, t]) ≤
+            capacity(level(stor), t) - value.(m[:stor_level][stor, t]) + TEST_ATOL
+    for t ∈ 𝒯)
+    @test all(
+        value.(m[:bat_res_up][stor, t]) ≤
+            value.(m[:stor_charge_use][stor, t]) - value.(m[:stor_discharge_use][stor, t]) +
+            capacity(discharge(stor), t) + TEST_ATOL
+    for t ∈ 𝒯)
+end


### PR DESCRIPTION
So far, we did not have a proper approach for modelling batteries with both charge and discharge capacities as well as efficiencies. This PR includes 2 new nodal types, a standard `Battery` type including charge and discharge capacities as well as a `ReserveBattery` type which can be included for modelling a reserve battery.

Both battery types can either have an infinite life or a life limited by the number of cycles. 

The PR is currently in draft status as I still have to include:

- [ ] an example,
- [ ] the documentation for the battery nodes, and
- [ ] checks for the nodes.

It is however already possible to check the implementation as this should not be changing.