### PR TITLE
Fixed when using investment models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.8.1"
+EnergyModelsBase = "0.8.3"
 EnergyModelsInvestments = "0.8"
 JuMP = "1.5"
 TimeStruct = "0.9"

--- a/ext/EMIExt/checks.jl
+++ b/ext/EMIExt/checks.jl
@@ -8,7 +8,7 @@ utilize investments at the time being, a separate function is required
 - No investment data is allowed
 """
 function EMB.check_node_data(
-    n::Union{HydroReservoir,HydroUnit,HydroGate},
+    n::Union{HydroReservoir,EMRP.HydroUnit,HydroGate},
     data::InvestmentData,
     𝒯,
     modeltype::AbstractInvestmentModel,

--- a/ext/EMIExt/utils.jl
+++ b/ext/EMIExt/utils.jl
@@ -25,17 +25,17 @@ function EMRP.multiplication_variables(
     else
         # Calculation of the multiplication with the installed capacity of the node
         prod = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
-            capacity(level(n), t_inv) * [:bat_stack_replace_b][n, t_inv]
+            capacity(level(n), t_inv) * m[:bat_stack_replace_b][n, t_inv]
         )
     end
     return prod
 end
 
-function capacity_max(n::AbstractBattery, t_inv, modeltype::AbstractInvestmentModel)
+function EMRP.capacity_max(n::AbstractBattery, t_inv, modeltype::AbstractInvestmentModel)
     if EMI.has_investment(n, :level)
-        max_installed = capacity(level(n), t_inv) * cycles(n)
+        max_installed = EMI.max_installed(EMI.investment_data(n, :level), t_inv) * EMRP.cycles(n)
     else
-        max_installed = EMI.max_installed(EMI.investment_data(n, :level)) * cycles(n)
+        max_installed = capacity(level(n), t_inv) * EMRP.cycles(n)
     end
     return max_installed
 end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -18,20 +18,20 @@ function EMB.check_node(n::NonDisRES, 𝒯, modeltype::EnergyModel, check_timepr
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
     EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
     @assert_or_log(
-        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
+        all(outputs(n, p) ≥ 0 for p ∈ outputs(n)),
         "The values for the Dictionary `output` must be non-negative."
     )
     @assert_or_log(
-        sum(profile(n, t) ≤ 1 for t ∈ 𝒯) == length(𝒯),
+        all(profile(n, t) ≤ 1 for t ∈ 𝒯),
         "The profile field must be less or equal to 1."
     )
     @assert_or_log(
-        sum(profile(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(profile(n, t) ≥ 0 for t ∈ 𝒯),
         "The profile field must be non-negative."
     )
 end
@@ -68,7 +68,7 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_tim
 
     if isa(par_charge, EMB.UnionCapacity)
         @assert_or_log(
-            sum(capacity(par_charge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            all(capacity(par_charge, t) ≥ 0 for t ∈ 𝒯),
             "The charge capacity must be non-negative."
         )
     end
@@ -76,7 +76,7 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_tim
         EMB.check_fixed_opex(par_charge, 𝒯ᴵⁿᵛ, check_timeprofiles)
     end
     @assert_or_log(
-        sum(capacity(par_level, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(par_level, t) ≥ 0 for t ∈ 𝒯),
         "The level capacity must be non-negative."
     )
     if isa(par_level, EMB.UnionOpexFixed)
@@ -84,7 +84,7 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_tim
     end
     if isa(par_discharge, EMB.UnionCapacity)
         @assert_or_log(
-            sum(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+            all(capacity(par_discharge, t) ≥ 0 for t ∈ 𝒯),
             "The discharge capacity must be non-negative."
         )
     end
@@ -120,7 +120,7 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_tim
     end
 
     @assert_or_log(
-        sum(level_init(n, t) ≤ capacity(par_level, t) for t ∈ 𝒯) == length(𝒯),
+        all(level_init(n, t) ≤ capacity(par_level, t) for t ∈ 𝒯),
         "The initial level `level_init` has to be less or equal to the max storage capacity."
     )
     for t_inv ∈ 𝒯ᴵⁿᵛ
@@ -132,17 +132,17 @@ function EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_tim
     end
 
     @assert_or_log(
-        sum(level_init(n, t) < 0 for t ∈ 𝒯) == 0,
+        all(level_init(n, t) ≥ 0 for t ∈ 𝒯),
         "The field `level_init` can not be negative."
     )
 
     # level_min
     @assert_or_log(
-        sum(level_min(n, t) < 0 for t ∈ 𝒯) == 0,
+        all(level_min(n, t) ≥ 0 for t ∈ 𝒯),
         "The field `level_min` can not be negative."
     )
     @assert_or_log(
-        sum(level_min(n, t) > 1 for t ∈ 𝒯) == 0,
+        all(level_min(n, t) ≤ 1 for t ∈ 𝒯),
         "The field `level_min` can not be larger than 1."
     )
 end
@@ -218,7 +218,7 @@ function EMB.check_node(n::HydroUnit, 𝒯, modeltype::EnergyModel, check_timepr
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
+        all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -4,7 +4,7 @@
 This method checks that the *[`NonDisRES`](@ref)* node is valid.
 
 It reuses the standard checks of a `Source` node through calling the function
-[`EMB.check_node_default`](@extef EnergyModelsBase.check_node_default), but adds an
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
 additional check on the data.
 
 ## Checks
@@ -35,7 +35,7 @@ end
 This method checks that the *[`HydroStorage`](@ref)* node is valid.
 
 It reuses the standard checks of a `Storage` node through calling the function
-[`EMB.check_node_default`](@extef EnergyModelsBase.check_node_default), but adds an
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
 additional check on the data.
 
 ## Checks
@@ -265,7 +265,7 @@ end
 This method checks that the *[`AbstractBattery`](@ref)* node is valid.
 
 It reuses the standard checks of a `Storage` node through calling the function
-[`EMB.check_node_default`](@extef EnergyModelsBase.check_node_default), but adds an
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
 additional check on the data.
 
 ## Checks
@@ -303,7 +303,7 @@ end
 This method checks that the *[`ReserveBattery`](@ref)* node is valid.
 
 It reuses the standard checks of a `Storage` node through calling the function
-[`EMB.check_node_default`](@extef EnergyModelsBase.check_node_default), but adds an
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
 additional check on the data.
 
 ## Checks

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -110,12 +110,12 @@ This method checks that the [`HydroReservoir`](@ref) node is valid.
   to be non-negative.
 - The `TimeProfile` of the field `fixed_opex` is required to be non-negative and
   accessible through a `StrategicPeriod` as outlined in the function
-  `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)` for the chosen composite type.
+  function [`EMB.check_fixed_opex()`](@extref EnergyModelsBase.check_fixed_opex) for the
+  field `level`, if included.
 - The `TimeProfile` of the `vol_inflow` of the `HydroReservoir` is required to be
   non-negative.
 """
 function EMB.check_node(n::HydroReservoir, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     par_level = level(n)
 
@@ -138,15 +138,18 @@ end
     EMB.check_node(n::HydroGate, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 This method checks that the *[`HydroGate`](@ref)* node is valid.
-
 ## Checks
  - The field `cap` is required to be non-negative.
+ - The value of the field `fixed_opex` is required to be non-negative and accessible through
+  a `StrategicPeriod` as outlined in the function [`EMB.check_fixed_opex()`](@extref EnergyModelsBase.check_fixed_opex).
 """
 function EMB.check_node(n::HydroGate, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     @assert_or_log(
         all(capacity(n, t) ≥ 0 for t ∈ 𝒯),
         "The capacity must be non-negative."
     )
+    EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
+EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,10 @@ const EMRP = EnergyModelsRenewableProducers
         include("test_battery.jl")
     end
 
+    @testset "RP | Checks" begin
+        include("test_checks.jl")
+    end
+
     @testset "RP | examples" begin
         include("test_examples.jl")
     end

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -1,0 +1,402 @@
+
+# Set the global to true to suppress the error message
+EMB.TEST_ENV = true
+
+# Test that the fields of a NonDisRES are correctly checked
+# - check_node(n::NonDisRES, 𝒯, modeltype::EnergyModel)
+@testset "NonDisRES" begin
+    # Function for setting up the system for testing a `NonDisRES` node
+    function check_graph(;
+        cap = FixedProfile(20),
+        profile = FixedProfile(0.5),
+        opex_fixed = FixedProfile(1),
+        output = Dict(Power => 1.0),
+    )
+
+        products = [Power, CO2]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = NonDisRES(
+            "wind",
+            cap,
+            profile,
+            FixedProfile(10),
+            opex_fixed,
+            output,
+        )
+        sink = RefSink(
+            "power_demand",
+            FixedProfile(10),
+            Dict(:surplus => FixedProfile(0), :deficit => StrategicProfile([1e3,2e2])),
+            Dict(Power => 1),
+        )
+
+        nodes = [source, sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[2])
+        ]
+
+        # Creation of the time structure and the used global data
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, SimpleTimes(10,1); op_per_strat)
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        return create_model(case, modeltype), case, modeltype
+    end
+
+    # Test that a wrong capacity is caught by the checks
+    @test_throws AssertionError check_graph(; cap=FixedProfile(-25))
+
+    # Test that a wrong profile is caught by the checks
+    @test_throws AssertionError check_graph(; profile=FixedProfile(-0.5))
+    @test_throws AssertionError check_graph(; profile=FixedProfile(1.5))
+
+    # Test that a wrong fixed OPEX is caught by the checks
+    @test_throws AssertionError check_graph(; opex_fixed=FixedProfile(-5))
+
+    # Test that a wrong output dictionary is caught
+    @test_throws AssertionError check_graph(; output=Dict(Power => -0.9))
+end
+
+# Test that the fields of a `HydroStorage` are correctly checked
+# - EMB.check_node(n::HydroStorage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+@testset "HydroStor and PumpedHydroStor" begin
+
+    # Function for setting up the system for testing an `PumpedHydroStorage` node
+    function check_graph(;
+        type = PumpedHydroStor,
+        charge_cap = FixedProfile(20),
+        charge_opex = FixedProfile(1),
+        level_cap = FixedProfile(50),
+        level_opex = FixedProfile(1),
+        discharge_cap = FixedProfile(20),
+        discharge_opex = FixedProfile(1),
+        level_init = StrategicProfile([20, 25, 30, 20]),
+        level_inflow = FixedProfile(10),
+        level_min = StrategicProfile([0.1, 0.2, 0.05, 0.1]),
+        input = Dict(Power => 0.9),
+        output = Dict(Power => 0.9),
+    )
+
+        products = [Power, CO2]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "power_source",
+            FixedProfile(20),
+            FixedProfile(50),
+            FixedProfile(1),
+            Dict(Power => 1),
+        )
+        if type <: PumpedHydroStor
+            hydro = PumpedHydroStor{CyclicRepresentative}(
+                "hydro",
+                StorCapOpexFixed(charge_cap, charge_opex),
+                StorCapOpexFixed(level_cap, level_opex),
+                StorCapOpexFixed(discharge_cap, discharge_opex),
+                level_init,
+                level_inflow,
+                level_min,
+                Power,
+                input,
+                output,
+            )
+        else
+            hydro = HydroStor{CyclicRepresentative}(
+                "hydro",
+                StorCapOpexFixed(level_cap, level_opex),
+                StorCapOpexFixed(discharge_cap, discharge_opex),
+                level_init,
+                level_inflow,
+                level_min,
+                Power,
+                input,
+                output,
+            )
+        end
+        sink = RefSink(
+            "power_demand",
+            FixedProfile(10),
+            Dict(:surplus => FixedProfile(0), :deficit => StrategicProfile([1e3,2e2])),
+            Dict(Power => 1),
+        )
+
+        nodes = [source, hydro, sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[3])
+            Direct("source-hydro", nodes[1], nodes[2])
+            Direct("bat-sink", nodes[2], nodes[3])
+        ]
+
+        # Creation of the time structure and the used global data
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, SimpleTimes(24,1); op_per_strat)
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        return create_model(case, modeltype), case, modeltype
+    end
+
+    # Test that a wrong capacity is caught by the checks
+    @test_throws AssertionError check_graph(; charge_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; level_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; discharge_cap=FixedProfile(-25))
+
+    # Test that a wrong fixed OPEX is caught by the checks
+    @test_throws AssertionError check_graph(; charge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; charge_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; level_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; level_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; discharge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; discharge_opex=OperationalProfile([10]))
+
+    # Test that a wrong input and output dictionaries are caught
+    @test_throws AssertionError check_graph(; input=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; input=Dict(Power => -0.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => -0.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.0, CO2 => 0.5))
+
+    # Test that a wrong initial level is caught by the checks.
+    level_init = StrategicProfile([50, 25, 45, 20])
+    @test_throws AssertionError check_graph(; level_init)
+    level_init = StrategicProfile([40, 25, 1, 20])
+    level_min = FixedProfile(.5)
+    @test_throws AssertionError check_graph(; level_init, level_min)
+    level_init = StrategicProfile([40, 25, -5, 20])
+    @test_throws AssertionError check_graph(; level_init)
+
+    # Test that a wrong minimum level is caught by the checks.
+    @test_throws AssertionError check_graph(; level_min=FixedProfile(-0.5))
+    @test_throws AssertionError check_graph(; level_min=FixedProfile(2))
+
+    # Test that the correct function is also called for HydroStor
+    type = HydroStor{CyclicRepresentative}
+    level_min = FixedProfile(-0.5)
+    @test_throws AssertionError check_graph(; type, level_min)
+end
+
+# Test that the fields of a `AbstractBattery` are correctly checked
+# - EMB.check_node(n::AbstractBattery, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+# - check_battery_life(n::AbstractBattery, bat_life::CycleLife, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+@testset "AbstractBattery" begin
+
+    # Function for setting up the system for testing an `AbstractBattery` node
+    function check_graph(;
+        charge_cap = FixedProfile(20),
+        charge_opex = FixedProfile(1),
+        level_cap = FixedProfile(50),
+        level_opex = FixedProfile(1),
+        discharge_cap = FixedProfile(20),
+        discharge_opex = FixedProfile(1),
+        input = Dict(Power => 0.9),
+        output = Dict(Power => 0.9),
+        cycles = 900,
+        degradation = 0.2,
+        stack_cost = FixedProfile(100),
+    )
+
+        products = [Power, CO2]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "power_source",
+            FixedProfile(20),
+            FixedProfile(50),
+            FixedProfile(1),
+            Dict(Power => 1),
+        )
+        battery = Battery{CyclicRepresentative}(
+            "battery",
+            StorCapOpexFixed(charge_cap, charge_opex),
+            StorCapOpexFixed(level_cap, level_opex),
+            StorCapOpexFixed(discharge_cap, discharge_opex),
+            Power,
+            input,
+            output,
+            CycleLife(
+                cycles,
+                degradation,
+                stack_cost
+            ),
+        )
+        sink = RefSink(
+            "power_demand",
+            FixedProfile(10),
+            Dict(:surplus => FixedProfile(0), :deficit => StrategicProfile([1e3,2e2])),
+            Dict(Power => 1),
+        )
+
+        nodes = [source, battery, sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[3])
+            Direct("source-bat", nodes[1], nodes[2])
+            Direct("bat-sink", nodes[2], nodes[3])
+        ]
+
+        # Creation of the time structure and the used global data
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, SimpleTimes(10,1); op_per_strat)
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        return create_model(case, modeltype), case, modeltype
+    end
+
+    # Test that a wrong capacity is caught by the checks
+    @test_throws AssertionError check_graph(; charge_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; level_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; discharge_cap=FixedProfile(-25))
+
+    # Test that a wrong fixed OPEX is caught by the checks
+    @test_throws AssertionError check_graph(; charge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; charge_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; level_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; level_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; discharge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; discharge_opex=OperationalProfile([10]))
+
+    # Test that a wrong input and output dictionaries are caught
+    @test_throws AssertionError check_graph(; input=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; input=Dict(Power => -0.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => -0.9))
+
+    # Test that a wrong battery life is caught
+    @test_throws AssertionError check_graph(; cycles=-10)
+    @test_throws AssertionError check_graph(; degradation=10)
+    @test_throws AssertionError check_graph(; degradation=-10)
+    @test_throws AssertionError check_graph(; stack_cost=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; stack_cost=OperationalProfile([10]))
+
+end
+
+# Test that the fields of a `ReserveBattery` are correctly checked
+# - EMB.check_node(n::ReserveBattery, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+# - check_battery_life(n::AbstractBattery, bat_life::CycleLife, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+@testset "ReserveBattery" begin
+
+    # Add the reserve resources
+    res_down = ResourceCarrier("Reserve Down", 0.0)
+    res_up = ResourceCarrier("Reserve Up", 0.0)
+
+    # Function for setting up the system for testing a `ReserveBattery` node
+    function check_graph(;
+        charge_cap = FixedProfile(20),
+        charge_opex = FixedProfile(1),
+        level_cap = FixedProfile(50),
+        level_opex = FixedProfile(1),
+        discharge_cap = FixedProfile(20),
+        discharge_opex = FixedProfile(1),
+        input = Dict(Power => 0.9),
+        output = Dict(Power => 0.9),
+        cycles = 900,
+        degradation = 0.2,
+        stack_cost = FixedProfile(100),
+    )
+
+        products = [Power, CO2, res_up, res_down]
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "power_source",
+            FixedProfile(20),
+            FixedProfile(50),
+            FixedProfile(1),
+            Dict(Power => 1),
+        )
+        battery = ReserveBattery{CyclicRepresentative}(
+            "battery",
+            StorCapOpexFixed(charge_cap, charge_opex),
+            StorCapOpexFixed(level_cap, level_opex),
+            StorCapOpexFixed(discharge_cap, discharge_opex),
+            Power,
+            input,
+            output,
+            CycleLife(
+                cycles,
+                degradation,
+                stack_cost
+            ),
+            [res_up],
+            [res_down],
+        )
+        sink = RefSink(
+            "power_demand",
+            FixedProfile(10),
+            Dict(:surplus => FixedProfile(0), :deficit => StrategicProfile([1e3,2e2])),
+            Dict(Power => 1),
+        )
+
+        nodes = [source, battery, sink]
+        links = [
+            Direct("source-sink", nodes[1], nodes[3])
+            Direct("source-bat", nodes[1], nodes[2])
+            Direct("bat-sink", nodes[2], nodes[3])
+        ]
+
+        # Creation of the time structure and the used global data
+        op_per_strat = 8760.0
+        T = TwoLevel(2, 2, SimpleTimes(10,1); op_per_strat)
+        modeltype = OperationalModel(
+            Dict(CO2 => FixedProfile(10)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2,
+        )
+
+        # Creation of the case dictionary
+        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+
+        return create_model(case, modeltype), case, modeltype
+    end
+
+    # Test that a wrong capacity is caught by the checks
+    @test_throws AssertionError check_graph(; charge_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; level_cap=FixedProfile(-25))
+    @test_throws AssertionError check_graph(; discharge_cap=FixedProfile(-25))
+
+    # Test that a wrong fixed OPEX is caught by the checks
+    @test_throws AssertionError check_graph(; charge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; charge_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; level_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; level_opex=OperationalProfile([10]))
+    @test_throws AssertionError check_graph(; discharge_opex=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; discharge_opex=OperationalProfile([10]))
+
+    # Test that a wrong input and output dictionaries are caught
+    @test_throws AssertionError check_graph(; input=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; input=Dict(Power => -0.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.9))
+    @test_throws AssertionError check_graph(; output=Dict(Power => -0.9))
+
+    # Test that a wrong battery life is caught
+    @test_throws AssertionError check_graph(; cycles=-10)
+    @test_throws AssertionError check_graph(; degradation=10)
+    @test_throws AssertionError check_graph(; degradation=-10)
+    @test_throws AssertionError check_graph(; stack_cost=FixedProfile(-5))
+    @test_throws AssertionError check_graph(; stack_cost=OperationalProfile([10]))
+
+    # Test that inclusion of reserves in the fields input or output is caught
+    @test_throws AssertionError check_graph(; input=Dict(Power => 1.9, res_up => 1))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.9, res_up => 1))
+    @test_throws AssertionError check_graph(; input=Dict(Power => 1.9, res_down => 1))
+    @test_throws AssertionError check_graph(; output=Dict(Power => 1.9, res_down => 1))
+end
+
+# Set the global again to false
+EMB.TEST_ENV = false


### PR DESCRIPTION
The previous version did produce an error when using `EnergyModelsInvestments`. This error was due to wrong function arguments and errors within the functions. As a consequence, EMRP could only be used in operational models. This is fixed in this PR.

In addition, the tests for the checks were extensively reworked and tests for investment models were included to avoid problems like that in the future.