### PR TITLE
Adjustment to EMB v0.9 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.6.5 (2025-02-10)
+
+* Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
+  * Increased version nubmer for EMB.
+  * Model worked without adjustments.
+  * Adjustments only required for simple understanding of changes.
+
 ## Version 0.6.4 (2024-11-29)
 
 * Fixed errors overseen from the inclusion of batteries and detailed hydropower.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRenewableProducers"
 uuid = "b007c34f-ba52-4995-ba37-fffe79fbde35"
 authors = ["Sigmund Eggen Holm, Julian Straus, Per Aaslid, Linn Emelie Schäffer"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -15,7 +15,7 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.8.3"
+EnergyModelsBase = "0.9.0"
 EnergyModelsInvestments = "0.8"
 JuMP = "1.5"
 TimeStruct = "0.9"

--- a/examples/detailed_hydro_power.jl
+++ b/examples/detailed_hydro_power.jl
@@ -216,14 +216,8 @@ function generate_detailed_hydropower()
         Direct("market_buy-availability", market_buy, av),
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T
-    )
-
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -239,8 +233,8 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_det_hydro_results(m, case)
     # Extract the nodes and the first strategic period from the data
-    upper, lower, generator_up, generator_low, pump = case[:nodes][[2,3,4,5,6]]
-    sp1 = first(strategic_periods(case[:T]))
+    upper, lower, generator_up, generator_low, pump = get_nodes(case)[[2, 3, 4, 5, 6]]
+    sp1 = first(strategic_periods(get_time_struct(case)))
 
     # System variables
     lvl_up = JuMP.Containers.rowtable(      # Upper reservoir level

--- a/examples/simple_battery.jl
+++ b/examples/simple_battery.jl
@@ -110,9 +110,8 @@ function generate_battery_example_data()
         Direct("battery-reserve_down", nodes[2], nodes[4])
     ]
 
-    # Create the case dictionary
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
-
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -128,9 +127,10 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_battery_results(m, case)
     # Extract the nodes and the first strategic period from the data
-    source, bat, sink = case[:nodes][[1, 2, 3]]
-    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
-    ops = collect(case[:T])[1:20]
+    source, bat, sink = get_nodes(case)[[1, 2, 3]]
+    𝒯 = get_time_struct(case)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    ops = collect(𝒯)[1:20]
 
     # System variables for operational periods
     source_use = JuMP.Containers.rowtable(      # Source usage

--- a/examples/simple_hydro_power.jl
+++ b/examples/simple_hydro_power.jl
@@ -103,9 +103,8 @@ function generate_hydro_example_data()
         Direct("av-demand", av, sink),
     ]
 
-    # Create the case dictionary
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
-
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -127,7 +126,7 @@ pretty_table(
 pretty_table(
     JuMP.Containers.rowtable(
         value,
-        m[:flow_out][case[:nodes][2:3], :, case[:products][2]];
+        m[:flow_out][get_nodes(case)[2:3], :, get_products(case)[2]];
         header = [:Node, :TimePeriod, :Production],
     ),
 )

--- a/test/test_battery.jl
+++ b/test/test_battery.jl
@@ -1,8 +1,7 @@
 function general_battery_tests(m, case)
     # Extract the data
-    𝒯 = case[:T]
-    𝒩 = case[:nodes]
-    stor = 𝒩[2]
+    𝒯 = get_time_struct(case)
+    stor = get_nodes(case)[2]
 
     # Test that the level balance is correct for standard periods
     @test all(
@@ -96,8 +95,8 @@ end
         op_per_strat = 8760.0
         T = TwoLevel(n_sp, 2, ops; op_per_strat)
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         # Creation and solving of the model
         m = create_model(case, modeltype)
@@ -109,9 +108,9 @@ end
 
     function battery_prev_usage_tests(m, case)
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        stor = case[:nodes][2]
+        stor = get_nodes(case)[2]
         # Test that the charge usage is correctly calculated and accounting for the length of
         # both operational and strategic periods in the first operational period of a
         # strategic period
@@ -148,11 +147,10 @@ end
 
     function battery_degradation_tests(m, case)
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
+
         # Test that the capacity limit is correctly enforced in the complete horizon
         # - constraints_usage_iterate:
         #   - Division by 50 to account for the installed storage capacity of the battery
@@ -185,9 +183,9 @@ end
         m, case, modeltype = small_graph(supply_price, el_demand)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        stor = case[:nodes][2]
+        stor = get_nodes(case)[2]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -207,11 +205,9 @@ end
         m, case, modeltype = small_graph(supply_price, el_demand; bat_life)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -224,11 +220,9 @@ end
         m, case, modeltype = small_graph(supply_price, el_demand; bat_life, n_sp=4)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -263,11 +257,9 @@ end
         )
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -312,11 +304,9 @@ end
         )
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -363,10 +353,9 @@ end
         m, case, modeltype = small_graph(supply_price, el_demand; ops)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
+        stor = get_nodes(case)[2]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -390,11 +379,9 @@ end
         m, case, modeltype = small_graph(supply_price, el_demand; ops, bat_life)
 
         # Extract the data
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-        𝒩 = case[:nodes]
-        stor = 𝒩[2]
-        sink = 𝒩[3]
+        stor, sink = get_nodes(case)[[2, 3]]
 
         # Run the standard tests
         general_battery_tests(m, case)
@@ -490,8 +477,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         # Creation and solving of the model
         m = create_model(case, modeltype)
@@ -507,10 +494,9 @@ end
     m, case, modeltype = small_graph(supply_price, el_demand)
 
     # Extract the data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    𝒩 = case[:nodes]
-    stor = 𝒩[2]
+    stor = get_nodes(case)[2]
 
     # Run the standard tests
     general_battery_tests(m, case)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -43,8 +43,8 @@ EMB.TEST_ENV = true
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -141,8 +141,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -223,8 +223,8 @@ end
             0.07,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -299,8 +299,8 @@ end
             0.07,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -344,7 +344,7 @@ end
     )
         products = [Water]
         # Creation of the node to be tested
-        nodes = [type(
+        nodes = EMB.Node[type(
             "hydro_unit",
             cap,
             PqPoints(pq_1, pq_2),
@@ -354,8 +354,6 @@ end
             Water,
             data,
         )]
-
-        links = []
 
         # Creation of the time structure and the used global data
         op_per_strat = 8760.0
@@ -367,8 +365,8 @@ end
             0.07,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, Vector[nodes], [Function[]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -475,8 +473,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end
@@ -581,8 +579,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
         return create_model(case, modeltype), case, modeltype
     end

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -263,23 +263,6 @@ end
         for field ∈ fieldnames(HydroStor{CyclicStrategic})
             @test getproperty(hydro_old, field) == getproperty(hydro_new, field)
         end
-
-        # Test that an empty input results in a running model
-        case, modeltype = small_graph()
-
-        # Updating the nodes and the links
-        push!(case[:nodes], hydro_new)
-        link_from = EMB.Direct(41, case[:nodes][4], case[:nodes][1], EMB.Linear())
-        push!(case[:links], link_from)
-        link_to = EMB.Direct(14, case[:nodes][1], case[:nodes][4], EMB.Linear())
-        push!(case[:links], link_to)
-
-        # Run the model
-        m = EMB.run_model(case, modeltype, OPTIMIZER)
-
-        # Run of the general and node tests
-        general_tests(m)
-        general_node_tests(m, case, hydro_new)
     end
 
     # Check that `PumpedHydroStor` nodes are correctly constructed when using simplified

--- a/test/test_nondisres.jl
+++ b/test/test_nondisres.jl
@@ -14,7 +14,7 @@
     m = EMB.run_model(case, modeltype, OPTIMIZER)
 
     # Extraction of the time structure
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
 
     # Run of the general tests
     general_tests(m)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -42,8 +42,8 @@ function small_graph(; source = nothing, sink = nothing, ops = SimpleTimes(24, 2
         CO2,
     )
 
-    # Creation of the case dictionary
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, modeltype
 end
 


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [v0.9.0 EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0)

The adjustments required minor changes in the design of the individual tests and examples. It did not require any changes to the code itself.