### PR TITLE
Adjustments to EMI v0.9 and EMB v0.10 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Version 0.7.0 (2026-04-16)
+
+### Breaking changes
+
+* Adjusted to the changes introduced in [`EnergyModelsInvestments` 0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and [`EnergyModelsBase` 0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):
+  * Breaking change required as early retirement is now allowed.
+  * Early retirement changes the model behavior.
+  * Test set was required to be adjusted, highlighting the potential impact of the changes
+
 ## Version 0.6.8 (2026-03-18)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRenewableProducers"
 uuid = "b007c34f-ba52-4995-ba37-fffe79fbde35"
 authors = ["Sigmund Eggen Holm, Julian Straus, Per Aaslid, Linn Emelie Schäffer"]
-version = "0.6.8"
+version = "0.7.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -17,9 +17,9 @@ EMIExt = "EnergyModelsInvestments"
 EMRHExt = "EnergyModelsRecedingHorizon"
 
 [compat]
-EnergyModelsBase = "0.9.0"
-EnergyModelsInvestments = "0.8"
-EnergyModelsRecedingHorizon = "0.1"
+EnergyModelsBase = "0.10"
+EnergyModelsInvestments = "0.9"
+EnergyModelsRecedingHorizon = "0.2"
 JuMP = "1.5"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -32,7 +32,7 @@ for further information regarding how you can translate your existing model to t
 - **`level_inflow::TimeProfile`** is the inflow of power per operational period.
 - **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
   has to remain in the `HydroStorage` node.
-- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
+- **`opex_var::TimeProfile`** are the variable operating expenses per GWh produced.
 - **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.
 - **`input::Dict{Resource, Real}`** are the stored and used resources. The values in the Dict
@@ -100,7 +100,7 @@ for further information regarding how you can translate your existing model to t
 - **`level_inflow::TimeProfile`** is the inflow of power per operational period.
 - **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
   has to remain in the `HydroStorage` node.
-- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
+- **`opex_var::TimeProfile`** are the variable operating expenses per GWh produced.
 - **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.
 - **`input::Dict{Resource, Real}`** are the stored and used resources. The values in the Dict
@@ -230,8 +230,8 @@ for further information regarding how you can translate your existing model to t
 - **`level_inflow::TimeProfile`** is the inflow of power per operational period.
 - **`level_min::TimeProfile`** is the minimum fraction of the reservoir capacity that
   has to remain in the `HydroStorage` node.
-- **`opex_var::TimeProfile`** are the variable operational expenses per GWh produced.
-- **`opex_var_pump::TimeProfile`** are the variable operational expenses per GWh pumped
+- **`opex_var::TimeProfile`** are the variable operating expenses per GWh produced.
+- **`opex_var_pump::TimeProfile`** are the variable operating expenses per GWh pumped
   into the storage.
 - **`opex_fixed::TimeProfile`** are the fixed operational costs of the storage caacity.
 - **`stor_res::ResourceCarrier`** is the stored `Resource`.

--- a/test/test_battery.jl
+++ b/test/test_battery.jl
@@ -286,7 +286,7 @@ end
     end
 
     @testset "SimpleTimes - Cycle limit, investments and reinvest" begin
-        bat_life = CycleLife(900, 0.2, StrategicProfile([2e5, 1e5, 2e4, 2e4]))
+        bat_life = CycleLife(900, 0.2, StrategicProfile([2e5, 1e5, 5e4, 5e4]))
         n_sp = 4
         sp_val = zeros(n_sp)
         sp_val[1] = 50
@@ -317,7 +317,7 @@ end
         # - capacity_reduction and constraints_capacity:
         #   - The value of 50 corresponds to the installed storage capacity of the battery
         #   - The value of 0.8 corresponds to 1-the final degradation percentage
-        #   - The value of 900 correspondsd to the cycle numbers
+        #   - The value of 900 corresponds to the cycle numbers
         @test all(
             value.(m[:stor_level][stor, t]) ≤
                 50 - 0.2 * value.(m[:bat_prev_use][stor, t]) / 900 + TEST_ATOL
@@ -329,7 +329,7 @@ end
         #   - 50 is the capacity
         #   - 2e4 is the cost for replacement
         #   - /2 to account for the duration of a strategic period
-        @test sum(value.(m[:opex_fixed][stor, t_inv]) for t_inv ∈ 𝒯ᴵⁿᵛ) ≈ 50 * 2e4 / 2
+        @test sum(value.(m[:opex_fixed][stor, t_inv]) for t_inv ∈ 𝒯ᴵⁿᵛ) ≈ 50 * 5e4 / 2
     end
 
     # Modelling of two days as one representative period each with typical demand and price


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [`EnergyModelsInvestments` v0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and the related changes in [`EnergyModelsBase` v0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0).

The adjustments did not require any changes except for dependency updates and minor modification in the test set. It is however prudent to do a major version increase to maintain the potential for bug fixes in the previous version. In addition, the behavior may change when investments are included.

> [!IMPORTANT]
> There will be other PRs before registering to include additional changes to the documentation and removal of legacy constructors.