### PR TITLE
Bug fix related to checks of `CycleLife` type and `TwoLevelTree`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.7.1 (2026-04-16)
+
+### Bug fixes
+
+* Fixed addition bugs with `StrategicProfile` and `TwoLevelTree` in the checks for the stack costs of `CycleLife` in the battery nodes.
+
 ## Version 0.7.0 (2026-04-16)
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # Release notes
 
-## Version 0.7.1 (2026-04-16)
+## Version 0.7.1 (2026-06-10)
 
 ### Bug fixes
 
-* Fixed addition bugs with `StrategicProfile` and `TwoLevelTree` in the checks for the stack costs of `CycleLife` in the battery nodes.
+* Fixed a bug in the checks when using `StrategicProfile` for the stack costs of `CycleLife` in a `AbstractBattery` node and `TwoLevelTree` as time structure.
 
 ## Version 0.7.0 (2026-04-16)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRenewableProducers"
 uuid = "b007c34f-ba52-4995-ba37-fffe79fbde35"
 authors = ["Sigmund Eggen Holm, Julian Straus, Per Aaslid, Linn Emelie Schäffer"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -17,7 +17,7 @@ EMIExt = "EnergyModelsInvestments"
 EMRHExt = "EnergyModelsRecedingHorizon"
 
 [compat]
-EnergyModelsBase = "0.10"
+EnergyModelsBase = "0.10.2"
 EnergyModelsInvestments = "0.9"
 EnergyModelsRecedingHorizon = "0.2"
 JuMP = "1.5"

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -403,17 +403,15 @@ function check_battery_life(
         "The value of the field `degradation` in the `CycleLife` must be smaller or equal to 1."
     )
 
-    if isa(stack_cost(bat_life), StrategicProfile) && check_timeprofiles
-        @assert_or_log(
-            length(stack_cost(bat_life).vals) == length(𝒯ᴵⁿᵛ),
-            "The timeprofile provided for the field `stack_cost` does not match the " *
-            "strategic structure."
-        )
+    sc_prof = stack_cost(bat_life)
+    if (isa(sc_prof, StrategicProfile) || isa(sc_prof, StrategicStochasticProfile)) &&
+        check_timeprofiles
+        EMB.check_profile(`stack_cost`, sc_prof, 𝒯; bool=false)
     end
 
     # Check for potential indexing problems
     message = "are not allowed for the field `stack_cost`."
-    bool_sp = EMB.check_strategic_profile(stack_cost(n), message)
+    bool_sp = EMB.check_strategic_profile(sc_prof, message)
 
     # Check that the value is positive in all cases
     if bool_sp

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -398,6 +398,7 @@ end
         cycles = 900,
         degradation = 0.2,
         stack_cost = FixedProfile(100),
+        T = TwoLevel(2, 2, SimpleTimes(10,1); op_per_strat=8760.0),
     )
 
         products = [Power, CO2]
@@ -437,9 +438,7 @@ end
             Direct("bat-sink", nodes[2], nodes[3])
         ]
 
-        # Creation of the time structure and the used global data
-        op_per_strat = 8760.0
-        T = TwoLevel(2, 2, SimpleTimes(10,1); op_per_strat)
+        # Creation of the used global data
         modeltype = OperationalModel(
             Dict(CO2 => FixedProfile(10)),
             Dict(CO2 => FixedProfile(0)),
@@ -476,8 +475,19 @@ end
     @test_throws AssertionError check_battery(; degradation=10)
     @test_throws AssertionError check_battery(; degradation=-10)
     @test_throws AssertionError check_battery(; stack_cost=FixedProfile(-5))
-    @test_throws AssertionError check_battery(; stack_cost=OperationalProfile([10]))
-
+    T = TwoLevelTree(2, [2], SimpleTimes(10, 1); op_per_strat=8760.0)
+    oprofile = OperationalProfile(ones(4))
+    profiles = [
+        oprofile,
+        StrategicProfile([4]),
+        StrategicProfile([oprofile, oprofile, oprofile, oprofile]),
+    ]
+    for tp ∈ profiles
+        @test_throws AssertionError check_battery(; stack_cost=tp)
+        @test_throws AssertionError check_battery(; stack_cost=tp, T)
+    end
+    tp  =StrategicStochasticProfile([[4]])
+    @test_throws AssertionError check_battery(; stack_cost=tp, T)
 end
 
 # Test that the fields of a `ReserveBattery` are correctly checked


### PR DESCRIPTION
This PR implements a bug fix when using `TwoLevelTree` as time structure . The problem was related to the checks for the stack replacement costs of `AbstractBattery` nodes with a `CycleLife` battery life whe using `TwoLevelTree` and a `StrategicProfile` for this parameter.

It is equivalent to the [#92 of `EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/92) and [#93 of `EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/93).